### PR TITLE
Use ExtensionInterface for ConfigurationDumper

### DIFF
--- a/DependencyInjection/Extension/ConfigurationDumper.php
+++ b/DependencyInjection/Extension/ConfigurationDumper.php
@@ -2,7 +2,7 @@
 
 namespace Knp\Bundle\RadBundle\DependencyInjection\Extension;
 
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 
 /**
  * ContianerExtension configuration dumper.
@@ -13,7 +13,7 @@ class ConfigurationDumper
     private $configPath;
     private $templatesPath;
 
-    public function __construct(Extension $extension, $configPath)
+    public function __construct(ExtensionInterface $extension, $configPath)
     {
         $this->extension     = $extension;
         $this->configPath    = $configPath;


### PR DESCRIPTION
Use Symfony\Component\DependencyInjection\Extension\ExtensionInterface for ConfigurationDumper instead of Symfony\Component\HttpKernel\DependencyInjection\Extension.
This fixes a bug when trying to use behat bundle
