### PR TITLE
Make rad bundle compatible with SF 2.1

### DIFF
--- a/Resources/skeleton/config/framework/config.yml
+++ b/Resources/skeleton/config/framework/config.yml
@@ -10,7 +10,6 @@ all:
     # esi:             ~
     translator:      { fallback: %locale% }
     secret:          %secret%
-    charset:         UTF-8
     form:            true
     csrf_protection: true
     validation:      { enable_annotations: true }
@@ -20,10 +19,6 @@ all:
         engines: ['twig']
         # assets_version: v2
         # assets_base_urls:
-        #    - //somecdn.com/
-    session:
-        default_locale: %locale%
-        auto_start:     true
 
     profiler: { only_exceptions: false }
 

--- a/Resources/skeleton/config/security/config.yml
+++ b/Resources/skeleton/config/security/config.yml
@@ -21,9 +21,10 @@ all:
         # FOSUserBundle: http://bit.ly/fosuserbundle or http://bit.ly/KnpU-FOS
         # docs: http://symfony.com/doc/current/cookbook/security/entity_provider.html
         in_memory:
-            users:
-                user:  { password: userpass, roles: [ 'ROLE_USER' ] }
-                admin: { password: adminpass, roles: [ 'ROLE_ADMIN' ] }
+            memory:
+                users:
+                    user:  { password: userpass, roles: [ 'ROLE_USER' ] }
+                    admin: { password: adminpass, roles: [ 'ROLE_ADMIN' ] }
 
         # database_users:
         #   entity:   { class: UserBundle:User, property: username }

--- a/Resources/skeleton/project/bin/configs
+++ b/Resources/skeleton/project/bin/configs
@@ -5,7 +5,7 @@ use Symfony\Component\Console\Output\ConsoleOutput;
 use Knp\Bundle\RadBundle\HttpKernel\RadKernel;
 use Knp\Bundle\RadBundle\DependencyInjection\Extension\ConfigurationDumper;
 
-$loader = require(__DIR__.'/../vendor/.composer/autoload.php');
+$loader = require(__DIR__.'/../vendor/autoload.php');
 $kernel = RadKernel::createAppKernel($loader, 'dev', true);
 $kernel->loadClassCache();
 $output = new ConsoleOutput();

--- a/Resources/skeleton/project/console
+++ b/Resources/skeleton/project/console
@@ -11,7 +11,7 @@ use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\ArgvInput;
 use Knp\Bundle\RadBundle\HttpKernel\RadKernel;
 
-$loader = require(__DIR__.'/vendor/.composer/autoload.php');
+$loader = require(__DIR__.'/vendor/autoload.php');
 
 $input = new ArgvInput();
 $env   = $input->getParameterOption(array('--env', '-e'), getenv('SYMFONY_ENV') ?: 'dev');

--- a/Resources/skeleton/project/phpunit.xml.dist
+++ b/Resources/skeleton/project/phpunit.xml.dist
@@ -11,7 +11,7 @@
     processIsolation            = "false"
     stopOnFailure               = "false"
     syntaxCheck                 = "false"
-    bootstrap                   = "vendor/.composer/autoload.php" >
+    bootstrap                   = "vendor/autoload.php" >
 
     <testsuites>
         <testsuite name="Knp Rad intro suite">

--- a/Resources/skeleton/project/tconsole
+++ b/Resources/skeleton/project/tconsole
@@ -10,7 +10,7 @@ set_time_limit(0);
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Knp\Bundle\RadBundle\HttpKernel\RadKernel;
 
-$loader = require(__DIR__.'/vendor/.composer/autoload.php');
+$loader = require(__DIR__.'/vendor/autoload.php');
 $kernel = RadKernel::createAppKernel($loader, 'test', false);
 
 $application = new Application($kernel);

--- a/Resources/skeleton/project/web/app.php
+++ b/Resources/skeleton/project/web/app.php
@@ -3,7 +3,7 @@
 use Symfony\Component\HttpFoundation\Request;
 use Knp\Bundle\RadBundle\HttpKernel\RadKernel;
 
-$loader = require(__DIR__.'/../vendor/.composer/autoload.php');
+$loader = require(__DIR__.'/../vendor/autoload.php');
 $kernel = RadKernel::createAppKernel($loader, 'prod', false);
 $kernel->loadClassCache();
 $kernel->handle(Request::createFromGlobals())->send();

--- a/Resources/skeleton/project/web/app_dev.php
+++ b/Resources/skeleton/project/web/app_dev.php
@@ -17,7 +17,7 @@ if (!in_array(@$_SERVER['REMOTE_ADDR'], array(
 use Symfony\Component\HttpFoundation\Request;
 use Knp\Bundle\RadBundle\HttpKernel\RadKernel;
 
-$loader = require(__DIR__.'/../vendor/.composer/autoload.php');
+$loader = require(__DIR__.'/../vendor/autoload.php');
 $kernel = RadKernel::createAppKernel($loader, 'dev', true);
 $kernel->loadClassCache();
 $kernel->handle(Request::createFromGlobals())->send();

--- a/Resources/skeleton/project/web/app_test.php
+++ b/Resources/skeleton/project/web/app_test.php
@@ -17,7 +17,7 @@ if (!in_array(@$_SERVER['REMOTE_ADDR'], array(
 use Symfony\Component\HttpFoundation\Request;
 use Knp\Bundle\RadBundle\HttpKernel\RadKernel;
 
-$loader = require(__DIR__.'/../vendor/.composer/autoload.php');
+$loader = require(__DIR__.'/../vendor/autoload.php');
 $kernel = RadKernel::createAppKernel($loader, 'test', true);
 $kernel->loadClassCache();
 $kernel->handle(Request::createFromGlobals())->send();

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -1,6 +1,6 @@
 <?php
 
-if (file_exists($file = __DIR__.'/../vendor/.composer/autoload.php')) {
+if (file_exists($file = __DIR__.'/../vendor/autoload.php')) {
     $autoload = require_once $file;
 } else {
     throw new RuntimeException('Install dependencies to run test suite.');

--- a/bin/generate-rad-project
+++ b/bin/generate-rad-project
@@ -15,7 +15,7 @@ if (!$vendorPath) {
 
 $projectPath = realpath($vendorPath.'/..');
 
-require $vendorPath.'/.composer/autoload.php';
+require $vendorPath.'/autoload.php';
 
 $projectName     = str_replace('/', '\\', $argv[1]);
 $applicationPath = $projectPath.'/src/'.str_replace('\\', '/', $projectName);

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name":        "Nubio/rad-bundle",
+    "name":        "nubio/rad-bundle",
     "type":        "symfony-bundle",
     "description": "Fork from KnpLabs to make it compatible for 2.1 version. This Bundle provides RAD development flow for Symfony2.",
     "keywords":    ["rad"],

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
 
     "require": {
         "php":              ">=5.3.3",
-        "symfony/symfony":  ">=2.1.*",
+        "symfony/symfony":  "2.1.*",
         "twig/extensions":  "1.0.*",
 
         "symfony/assetic-bundle":  "2.1.*",

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
-    "name":        "knplabs/rad-bundle",
+    "name":        "Nubio/rad-bundle",
     "type":        "symfony-bundle",
-    "description": "This Bundle provides RAD development flow for Symfony2.",
+    "description": "Fork from KnpLabs to make it compatible for 2.1 version. This Bundle provides RAD development flow for Symfony2.",
     "keywords":    ["rad"],
     "homepage":    "http://rad.knplabs.com",
     "license":     "MIT",
@@ -13,12 +13,12 @@
     ],
 
     "require": {
-        "php":              ">=5.3.2",
-        "symfony/symfony":  ">=2.0.10,<2.1.0",
-        "twig/extensions":  "*",
+        "php":              ">=5.3.3",
+        "symfony/symfony":  ">=2.1.*",
+        "twig/extensions":  "1.0.*",
 
-        "symfony/assetic-bundle":  "2.0.*",
-        "sensio/generator-bundle": "2.0.*"
+        "symfony/assetic-bundle":  "2.1.*",
+        "sensio/generator-bundle": "2.1.*"
     },
 
     "autoload": {


### PR DESCRIPTION
Hello,

Some littles changes to make the bundle comptabile for SF 2.1.

See issue #29

Note: if accepted I should change the package name of course, it was to test the installation via composer and packagist.
