### PR TITLE
Flash messages

### DIFF
--- a/Controller/Controller.php
+++ b/Controller/Controller.php
@@ -5,6 +5,7 @@ namespace Knp\RadBundle\Controller;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller as BaseController;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpFoundation\Request;
+use Knp\RadBundle\Flash;
 
 class Controller extends BaseController
 {
@@ -87,17 +88,9 @@ class Controller extends BaseController
         throw $this->createNotFoundException('Resource not found');
     }
 
-    protected function addFlashf()
+    protected function addFlash($type, $message, array $parameters = array(), $pluralization = null)
     {
-        $args = func_get_args();
-        $type = array_shift($args);
-
-        $this->addFlash($type, call_user_func_array('sprintf', $args));
-    }
-
-    protected function addFlash($type, $message)
-    {
-        $this->getFlashBag()->add($type, $message);
+        $this->getFlashBag()->add($type, new Flash\Message($message, $parameters, $pluralization));
     }
 
     protected function createObjectForm($object, $purpose = null, array $options = array())

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -34,7 +34,13 @@ class Configuration implements ConfigurationInterface
                 ->booleanNode('routing_loader')->defaultTrue()->end()
                 ->booleanNode('form_manager')->defaultTrue()->end()
                 ->booleanNode('datatable')->defaultTrue()->end()
-                ->booleanNode('flashes')->defaultTrue()->end()
+                ->arrayNode('flashes')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->booleanNode('enabled')->defaultTrue()->end()
+                        ->scalarNode('trans_catalog')->defaultValue('messages')->end()
+                    ->end()
+                ->end()
             ->end()
         ;
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -34,6 +34,7 @@ class Configuration implements ConfigurationInterface
                 ->booleanNode('routing_loader')->defaultTrue()->end()
                 ->booleanNode('form_manager')->defaultTrue()->end()
                 ->booleanNode('datatable')->defaultTrue()->end()
+                ->booleanNode('flashes')->defaultTrue()->end()
             ->end()
         ;
 

--- a/DependencyInjection/KnpRadExtension.php
+++ b/DependencyInjection/KnpRadExtension.php
@@ -50,7 +50,8 @@ class KnpRadExtension extends Extension
             $loader->load('datatable.xml');
         }
 
-        if ($config['flashes']) {
+        $container->setParameter('knp_rad.flashes.trans_catalog', $config['flashes']['trans_catalog']);
+        if ($config['flashes']['enabled']) {
             $loader->load('flashes.xml');
         }
     }

--- a/DependencyInjection/KnpRadExtension.php
+++ b/DependencyInjection/KnpRadExtension.php
@@ -49,5 +49,9 @@ class KnpRadExtension extends Extension
         if ($config['datatable']) {
             $loader->load('datatable.xml');
         }
+
+        if ($config['flashes']) {
+            $loader->load('flashes.xml');
+        }
     }
 }

--- a/Flash/Message.php
+++ b/Flash/Message.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Knp\RadBundle\Flash;
+
+class Message
+{
+    private $template;
+
+    public function __construct($template, array $parameters = array(), $pluralization = null)
+    {
+        $this->template      = $template;
+        $this->parameters    = $parameters;
+        $this->pluralization = $pluralization;
+    }
+
+    public function getTemplate()
+    {
+        return $this->template;
+    }
+
+    public function getParameters()
+    {
+        return $this->parameters;
+    }
+
+    public function getPluralization()
+    {
+        return $this->pluralization;
+    }
+}

--- a/Flash/MessageRenderer.php
+++ b/Flash/MessageRenderer.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Knp\RadBundle\Flash;
+
+use Symfony\Component\Translation\TranslatorInterface;
+
+class MessageRenderer
+{
+    private $translator;
+    private $transCatalog;
+
+    public function __construct(TranslatorInterface $translator, $transCatalog = 'messages')
+    {
+        $this->translator   = $translator;
+        $this->transCatalog = $transCatalog;
+    }
+
+    public function render(Message $message, $transCatalog = null)
+    {
+        return $this->translator->trans(
+            $message->getTemplate(),
+            $message->getParameters(),
+            $transCatalog ?: $this->transCatalog,
+            $message->getPluralization()
+        );
+    }
+}

--- a/Resources/config/flashes.xml
+++ b/Resources/config/flashes.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="knp_rad.flash.message_renderer.class">Knp\RadBundle\Flash\MessageRenderer</parameter>
+        <parameter key="knp_rad.twig.flash_extension.class">Knp\RadBundle\Twig\FlashExtension</parameter>
+    </parameters>
+
+    <services>
+        <service id="knp_rad.flash.message_renderer" class="%knp_rad.flash.message_renderer.class%">
+            <argument type="service" id="translator" />
+        </service>
+
+        <service id="knp_rad.twig.flash_extension" class="%knp_rad.twig.flash_extension.class%">
+            <argument type="service" id="knp_rad.flash.message_renderer" />
+            <argument type="service" id="session" />
+            <tag name="twig.extension" />
+        </service>
+    </services>
+
+</container>

--- a/Resources/config/flashes.xml
+++ b/Resources/config/flashes.xml
@@ -12,6 +12,7 @@
     <services>
         <service id="knp_rad.flash.message_renderer" class="%knp_rad.flash.message_renderer.class%">
             <argument type="service" id="translator" />
+            <argument>%knp_rad.flashes.trans_catalog%</argument>
         </service>
 
         <service id="knp_rad.twig.flash_extension" class="%knp_rad.twig.flash_extension.class%">

--- a/Twig/FlashExtension.php
+++ b/Twig/FlashExtension.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Knp\RadBundle\Twig;
+
+use Knp\RadBundle\Flash\Message;
+use Knp\RadBundle\Flash\MessageRenderer;
+use Symfony\Component\HttpFoundation\Session\Session;
+
+/**
+ * Twig extension to for flash messages rendering
+ */
+class FlashExtension extends \Twig_Extension
+{
+    private $renderer;
+    private $session;
+
+    public function __construct(MessageRenderer $renderer, Session $session)
+    {
+        $this->renderer = $renderer;
+        $this->session  = $session;
+    }
+
+    public function getTokenParsers()
+    {
+        return array(
+            new FlashesTokenParser()
+        );
+    }
+
+    public function getName()
+    {
+        return 'flash';
+    }
+
+    public function renderMessage($message, $catalog = null)
+    {
+        if (!$message instanceof Message) {
+            return $message;
+        }
+
+        return $this->renderer->render($message, $catalog);
+    }
+
+    public function getFlashes($types = null)
+    {
+        $flashBag = $this->session->getFlashBag();
+
+        if (null === $types) {
+            return $flashBag->all();
+        }
+
+        if (!is_array($types)) {
+            $types = array($types);
+        }
+
+        $flashes = array();
+        foreach ($types as $type) {
+            $flashes[$type] = $flashBag->get($type, array());
+        }
+
+        return $flashes;
+    }
+}

--- a/Twig/FlashesNode.php
+++ b/Twig/FlashesNode.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Knp\RadBundle\Twig;
+
+use Twig_Node;
+use Twig_NodeInterface;
+use Twig_Node_Expression;
+use Twig_Compiler;
+
+class FlashesNode extends Twig_Node
+{
+    public function __construct(Twig_Node_Expression $types = null, Twig_Node_Expression $catalog = null, Twig_NodeInterface $body, $lineno)
+    {
+        $nodes = array('body' => $body);
+        if (null !== $types) {
+            $nodes['types'] = $types;
+        }
+        if (null !== $catalog) {
+            $nodes['catalog'] = $catalog;
+        }
+
+        parent::__construct($nodes, array(), $lineno, 'flashes');
+    }
+
+    public function compile(Twig_Compiler $compiler)
+    {
+        $compiler->addDebugInfo($this);
+
+        $compiler->write('$types   = ');
+        if ($this->hasNode('types')) {
+            $compiler->subcompile($this->getNode('types'));
+        } else {
+            $compiler->repr(null);
+        }
+        $compiler->raw(";\n");
+
+        $compiler->write('$catalog = ');
+        if ($this->hasNode('catalog')) {
+            $compiler->subcompile($this->getNode('catalog'));
+        } else {
+            $compiler->repr(null);
+        }
+        $compiler->raw(";\n");
+
+        $compiler
+            ->write("\$savedContext = null;")
+            ->write("foreach (\$this->env->getExtension('flash')->getFlashes(\$types) as \$type => \$flashes) {\n")
+            ->indent()
+            ->write("foreach (\$flashes as \$flash) {\n")
+            ->indent()
+            ->write("if (null === \$savedContext) {\n")
+            ->indent()
+            ->write("\$savedContext = \$context;\n")
+            ->outdent()
+            ->write("}\n")
+            ->write('$context = array(')
+            ->raw("\n")
+            ->indent()
+            ->write("'type'    => \$type,\n")
+            ->write("'message' => \$this->env->getExtension('flash')->renderMessage(\$flash, \$catalog)\n")
+            ->outdent()
+            ->write(");\n")
+            ->subcompile($this->getNode('body'))
+            ->outdent()
+            ->write("}\n")
+            ->outdent()
+            ->write("}\n")
+            ->write("if (null !== \$savedContext) {\n")
+            ->indent()
+            ->write("\$context = \$savedContext;\n")
+            ->write("unset(\$savedContext);\n")
+            ->outdent()
+            ->write("}\n")
+            ->write("unset(\$types, \$catalog);\n")
+        ;
+    }
+}

--- a/Twig/FlashesNodeFactory.php
+++ b/Twig/FlashesNodeFactory.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Knp\RadBundle\Twig;
+
+use Twig_NodeInterface;
+use Twig_Node_Expression;
+
+class FlashesNodeFactory
+{
+    /**
+     * @todo reintroduct typehints
+     */
+    public function createFlashesNode(/* Twig_Node_Expression */ $types = null, /* Twig_Node_Expression */ $catalog = null, Twig_NodeInterface $body, $line)
+    {
+        return new FlashesNode($types, $catalog, $body, $line);
+    }
+}

--- a/Twig/FlashesTokenParser.php
+++ b/Twig/FlashesTokenParser.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Knp\RadBundle\Twig;
+
+use Twig_Token;
+use Twig_TokenParser;
+
+/**
+ * Token parser for "flashes" tags
+ */
+class FlashesTokenParser extends Twig_TokenParser
+{
+    private $nodeFactory;
+
+    public function __construct(FlashesNodeFactory $nodeFactory = null)
+    {
+        $this->nodeFactory = $nodeFactory ?: new FlashesNodeFactory;
+    }
+
+    public function parse(Twig_Token $token)
+    {
+        $stream     = $this->parser->getStream();
+        $exprParser = $this->parser->getExpressionParser();
+
+        $typesExpr = null;
+        if (!$stream->test(Twig_Token::NAME_TYPE, 'using') && !$stream->test(Twig_Token::BLOCK_END_TYPE)) {
+            $typesExpr = $exprParser->parseExpression();
+        }
+
+        $catalogExpr = null;
+        if ($stream->test(Twig_Token::NAME_TYPE, 'using')) {
+            $stream->expect(Twig_Token::NAME_TYPE, 'using');
+            $stream->expect(Twig_Token::NAME_TYPE, 'catalog');
+
+            $catalogExpr = $exprParser->parseExpression();
+        }
+
+        $stream->expect(Twig_Token::BLOCK_END_TYPE);
+
+        $body = $this->parser->subparse(array($this, 'isEndTag'), true);
+
+        $stream->expect(Twig_Token::BLOCK_END_TYPE);
+
+        return $this->nodeFactory->createFlashesNode($typesExpr, $catalogExpr, $body, $token->getLine());
+    }
+
+    public function getTag()
+    {
+        return 'flashes';
+    }
+
+    public function isEndTag(Twig_Token $token)
+    {
+        return $token->test('endflashes');
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
         "symfony/security":                  ">=2.1",
         "symfony/swiftmailer-bundle":        "2.1.*",
         "doctrine/orm":                      ">=2.2.3,<2.4-dev",
-        "doctrine/doctrine-fixtures-bundle": "*"
+        "doctrine/doctrine-fixtures-bundle": "*",
+        "twig/twig": "*"
     },
     "suggest": {
         "symfony/form":                      "To take advantage of the Rad Form Manager",

--- a/spec/Flash/Message.php
+++ b/spec/Flash/Message.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace spec\Knp\RadBundle\Flash;
+
+use PHPSpec2\ObjectBehavior;
+
+class Message extends ObjectBehavior
+{
+    function let()
+    {
+        $this->beConstructedWith('Hello {{ name }}!', array('{{ name }}' => 'George'), 123);
+    }
+
+    function it_should_have_a_template_accessor()
+    {
+        $this->getTemplate()->shouldReturn('Hello {{ name }}!');
+    }
+
+    function it_should_have_a_parameters_accessor()
+    {
+        $this->getParameters()->shouldReturn(array('{{ name }}' => 'George'));
+    }
+
+    function it_should_have_a_pluralization_accessor()
+    {
+        $this->getPluralization()->shouldReturn(123);
+    }
+
+    function it_should_use_null_as_default_pluralization()
+    {
+        $this->beConstructedWith('Hello {{ name }}!', array('{{ name }}' => 'George'));
+
+        $this->getPluralization()->shouldReturn(null);
+    }
+
+    function it_should_use_empty_array_as_default_parameters()
+    {
+        $this->beConstructedWith('Hello {{ name }}!');
+
+        $this->getParameters()->shouldReturn(array());
+    }
+}

--- a/spec/Flash/MessageRenderer.php
+++ b/spec/Flash/MessageRenderer.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace spec\Knp\RadBundle\Flash;
+
+use PHPSpec2\ObjectBehavior;
+
+class MessageRenderer extends ObjectBehavior
+{
+    /**
+     * @param  Knp\RadBundle\Flash\Message                       $message
+     * @param  Symfony\Component\Translation\TranslatorInterface $translator
+     */
+    function let($message, $translator)
+    {
+        $this->beConstructedWith($translator, 'default_catalog');
+
+        $message->getTemplate()->willReturn('Hello {{ name }}!');
+        $message->getParameters()->willReturn(array('{{ name }}' => 'George'));
+        $message->getPluralization()->willReturn(123);
+    }
+
+    function it_should_translate_the_message_using_the_default_catalog($message, $translator)
+    {
+        $translator
+            ->trans('Hello {{ name }}!', array('{{ name }}' => 'George'), 'default_catalog', 123)
+            ->shouldBeCalled()
+            ->willReturn('Bonjour George !')
+        ;
+
+        $this->render($message)->shouldReturn('Bonjour George !');
+    }
+
+    function it_should_use_the_specified_translations_catalog($message, $translator)
+    {
+        $translator
+            ->trans(ANY_ARGUMENT, ANY_ARGUMENT, 'custom_catalog', ANY_ARGUMENT)
+            ->shouldBeCalled()
+            ->willReturn('Bonjour George !')
+        ;
+
+        $this->render($message, 'custom_catalog')->shouldReturn('Bonjour George !');
+    }
+
+    function it_should_use_the_messages_catalog_by_default($message, $translator)
+    {
+        $this->beConstructedWith($translator);
+
+        $translator
+            ->trans(ANY_ARGUMENT, ANY_ARGUMENT, 'messages', ANY_ARGUMENT)
+            ->shouldBeCalled()
+            ->willReturn('Bonjour George !')
+        ;
+
+        $this->render($message)->shouldReturn('Bonjour George !');
+    }
+}

--- a/spec/Twig/FlashExtension.php
+++ b/spec/Twig/FlashExtension.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace spec\Knp\RadBundle\Twig;
+
+use PHPSpec2\ObjectBehavior;
+
+class FlashExtension extends ObjectBehavior
+{
+    /**
+     * @param  Knp\RadBundle\Flash\Message                                      $flash
+     * @param  Knp\RadBundle\Flash\MessageRenderer                              $renderer
+     * @param  Symfony\Component\HttpFoundation\Session\Session                 $session
+     * @param  Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface $flashes
+     */
+    function let($renderer, $session, $flashes)
+    {
+        $this->beConstructedWith($renderer, $session);
+
+        $session->getFlashBag()->willReturn($flashes);
+    }
+
+    function it_should_be_a_twig_extension()
+    {
+        $this->shouldBeAnInstanceOf('Twig_ExtensionInterface');
+    }
+
+    function it_should_be_named_flash()
+    {
+        $this->getName()->shouldReturn('flash');
+    }
+
+    function it_should_register_a_flashes_token_parser()
+    {
+        $parsers = $this->getTokenParsers();
+        $parsers->shouldHaveCount(1);
+        $parsers[0]->shouldBeAnInstanceOf('Knp\RadBundle\Twig\FlashesTokenParser');
+    }
+
+    function its_renderMessage_should_render_a_message_instance($renderer, $flash)
+    {
+        $renderer->render($flash, null)->shouldBeCalled()->willReturn('Rendered flash');
+
+        $this->renderMessage($flash)->shouldReturn('Rendered flash');
+    }
+
+    function its_renderMessage_should_allow_to_specify_a_custom_catalog($renderer, $flash)
+    {
+        $renderer->render($flash, 'custom_catalog')->shouldBeCalled()->willReturn('Rendered flash');
+
+        $this->renderMessage($flash, 'custom_catalog')->shouldReturn('Rendered flash');
+    }
+
+    function its_renderMessage_should_not_change_non_message_values($renderer)
+    {
+        $renderer->render(ANY_ARGUMENTS)->shouldNotBeCalled();
+
+        $this->renderMessage('Some string')->shouldReturn('Some string');
+    }
+
+    function its_getFlashes_should_return_all_the_flashes($flashes)
+    {
+        $flashes->all()->shouldBeCalled()->willReturn(array('success' => array('some success')));
+
+        $this->getFlashes()->shouldReturn(array('success' => array('some success')));
+    }
+
+    function its_getFlashes_should_allow_to_specify_a_single_type($flashes)
+    {
+        $flashes->all()->shouldNotBeCalled();
+        $flashes->get('success', array())->shouldBeCalled()->willReturn(array('first success', 'second success'));
+
+        $this->getFlashes('success')->shouldReturn(array(
+            'success' => array('first success', 'second success'),
+        ));
+    }
+
+    function its_getFlashes_should_allow_to_specify_an_array_of_types($flashes)
+    {
+        $flashes->all()->shouldNotBeCalled();
+        $flashes->get('success', array())->shouldBeCalled()->willReturn(array('first success', 'second success'));
+        $flashes->get('failure', array())->shouldBeCalled()->willReturn(array('first failure', 'second failure'));
+
+        $this->getFlashes(array('success', 'failure'))->shouldReturn(array(
+            'success' => array('first success', 'second success'),
+            'failure' => array('first failure', 'second failure')
+        ));
+    }
+}

--- a/spec/Twig/FlashesNode.php
+++ b/spec/Twig/FlashesNode.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace spec\Knp\RadBundle\Twig;
+
+use PHPSpec2\ObjectBehavior;
+
+class FlashesNode extends ObjectBehavior
+{
+    /**
+     * @param  Twig_Node_Expression $types
+     * @param  Twig_Node_Expression $catalog
+     * @param  Twig_NodeInterface   $body
+     */
+    function let($types, $catalog, $body)
+    {
+        $this->beConstructedWith($types, $catalog, $body, 123);
+    }
+
+    function it_should_be_a_twig_node()
+    {
+        $this->shouldBeAnInstanceOf('Twig_Node');
+    }
+
+    function it_should_be_constructible_with_no_types($catalog, $body)
+    {
+        $this->shouldNotThrow()->during('__construct', array(null, $catalog, $body, 123));
+    }
+
+    function it_should_be_constructible_with_no_catalog($types, $body)
+    {
+        $this->shouldNotThrow()->during('__construct', array($types, null, $body, 123));
+    }
+
+    /**
+     * @param  Twig_Compiler $compiler
+     */
+    function it_should_compile($compiler, $types, $catalog, $body)
+    {
+        $compiler->addDebugInfo($this)->shouldBeCalled()->willReturn($compiler);
+        $compiler->subcompile($types)->shouldBeCalled()->willReturn($compiler);
+        $compiler->subcompile($catalog)->shouldBeCalled()->willReturn($compiler);
+        $compiler->subcompile($body)->shouldBeCalled()->willReturn($compiler);
+
+        $compiler->write(ANY_ARGUMENTS)->willReturn($compiler);
+        $compiler->raw(ANY_ARGUMENTS)->willReturn($compiler);
+        $compiler->indent(ANY_ARGUMENTS)->willReturn($compiler);
+        $compiler->outdent(ANY_ARGUMENTS)->willReturn($compiler);
+
+        $this->compile($compiler);
+    }
+}

--- a/spec/Twig/FlashesNodeFactory.php
+++ b/spec/Twig/FlashesNodeFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace spec\Knp\RadBundle\Twig;
+
+use PHPSpec2\ObjectBehavior;
+
+class FlashesNodeFactory extends ObjectBehavior
+{
+    /**
+     * @param  Twig_Node_Expression $types
+     * @param  Twig_Node_Expression $catalog
+     * @param  Twig_NodeInterface   $body
+     */
+    function let()
+    {
+    }
+
+    function it_should_create_flashes_node_instances($types, $catalog, $body)
+    {
+        $this->createFlashesNode($types, $catalog, $body, 123)->shouldBeAnInstanceOf('Knp\RadBundle\Twig\FlashesNode');
+    }
+
+    function it_should_allow_to_create_flashes_node_with_no_types($catalog, $body)
+    {
+        $this->createFlashesNode(null, $catalog, $body, 123)->shouldBeAnInstanceOf('Knp\RadBundle\Twig\FlashesNode');
+    }
+
+    function it_should_allow_to_create_flashes_node_with_no_catalog($types, $body)
+    {
+        $this->createFlashesNode($types, null, $body, 123)->shouldBeAnInstanceOf('Knp\RadBundle\Twig\FlashesNode');
+    }
+}

--- a/spec/Twig/FlashesTokenParser.php
+++ b/spec/Twig/FlashesTokenParser.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace spec\Knp\RadBundle\Twig;
+
+use PHPSpec2\ObjectBehavior;
+
+class FlashesTokenParser extends ObjectBehavior
+{
+    /**
+     * @param  Twig_Parser                           $parser
+     * @param  Twig_ExpressionParser                 $exprParser
+     * @param  Twig_TokenStream                      $stream
+     * @param  Twig_Token                            $token
+     * @param  Twig_NodeInterface                    $body
+     * @param  Knp\RadBundle\Twig\FlashesNodeFactory $nodeFactory
+     * @param  Knp\RadBundle\Twig\FlashesNode        $node
+     */
+    function let($parser, $exprParser, $stream, $nodeFactory, $token)
+    {
+        $this->beConstructedWith($nodeFactory);
+
+        $parser->getStream()->willReturn($stream);
+        $parser->getExpressionParser()->willReturn($exprParser);
+
+        $token->getLine()->willReturn(123);
+
+        $this->setParser($parser);
+    }
+
+    function it_should_be_a_twig_token_parser()
+    {
+        $this->shouldBeAnInstanceOf('Twig_TokenParserInterface');
+    }
+
+    function it_should_handle_flashes_tags()
+    {
+        $this->getTag()->shouldReturn('flashes');
+    }
+
+    /**
+     * {% flashes {expr:types} using catalog {expr:catalog} %}
+     *      <div class="flash {{ type }}">{{ message }}</div>
+     * {% endflashes %}
+     *
+     * @param  Twig_Node_Expression $types
+     * @param  Twig_Node_Expression $catalog
+     */
+    function it_should_parse_complete_flashes_tag(
+        $parser, $exprParser, $stream, $body, $nodeFactory, $node, $token, $types, $catalog
+    )
+    {
+        $stream->test(\Twig_Token::NAME_TYPE, 'using')->willReturn(false);
+        $stream->test(\Twig_Token::BLOCK_END_TYPE)->willReturn(false);
+        $exprParser->parseExpression()->willReturn($types);
+
+        $stream->test(\Twig_Token::NAME_TYPE, 'using')->willReturn(true);
+        $stream->expect(\Twig_Token::NAME_TYPE, 'using');
+        $stream->expect(\Twig_Token::NAME_TYPE, 'catalog');
+
+        $exprParser->parseExpression()->willReturn($catalog);
+
+        $stream->expect(\Twig_Token::BLOCK_END_TYPE);
+
+        $parser->subparse(array($this, 'isEndTag'), true)->willReturn($body);
+
+        $stream->expect(\Twig_Token::BLOCK_END_TYPE);
+
+        $nodeFactory->createFlashesNode($types, $catalog, $body, 123)->willReturn($node);
+
+        $this->parse($token)->shouldReturn($node);
+    }
+
+    /**
+     * {% flashes {expr:types} %}
+     *      <div class="flash {{ type }}">{{ message }}</div>
+     * {% endflashes %}
+     *
+     * @param  Twig_Node_Expression $types
+     */
+    function it_should_parse_flashes_tag_with_no_specified_catalog(
+        $parser, $exprParser, $stream, $body, $nodeFactory, $node, $token, $types
+    )
+    {
+        $stream->test(\Twig_Token::NAME_TYPE, 'using')->willReturn(false);
+        $stream->test(\Twig_Token::BLOCK_END_TYPE)->willReturn(false);
+        $exprParser->parseExpression()->willReturn($types);
+
+        $stream->test(\Twig_Token::NAME_TYPE, 'using')->willReturn(false);
+
+        $stream->expect(\Twig_Token::BLOCK_END_TYPE);
+
+        $parser->subparse(array($this, 'isEndTag'), true)->willReturn($body);
+
+        $stream->expect(\Twig_Token::BLOCK_END_TYPE);
+
+        $nodeFactory->createFlashesNode($types, null, $body, 123)->willReturn($node);
+
+        $this->parse($token)->shouldReturn($node);
+    }
+
+    /**
+     * {% flashes using catalog {expr:catalog} %}
+     *      <div class="flash {{ type }}">{{ message }}</div>
+     * {% endflashes %}
+     *
+     * @param  Twig_Node_Expression $catalog
+     */
+    function it_should_parse_flashes_tag_with_no_specified_types(
+        $parser, $exprParser, $stream, $body, $nodeFactory, $node, $token, $catalog
+    )
+    {
+        $stream->test(\Twig_Token::NAME_TYPE, 'using')->willReturn(true);
+
+        $stream->test(\Twig_Token::NAME_TYPE, 'using')->willReturn(true);
+        $stream->expect(\Twig_Token::NAME_TYPE, 'using');
+        $stream->expect(\Twig_Token::NAME_TYPE, 'catalog');
+
+        $exprParser->parseExpression()->willReturn($catalog);
+
+        $stream->expect(\Twig_Token::BLOCK_END_TYPE);
+
+        $parser->subparse(array($this, 'isEndTag'), true)->willReturn($body);
+
+        $stream->expect(\Twig_Token::BLOCK_END_TYPE);
+
+        $nodeFactory->createFlashesNode(null, $catalog, $body, 123)->willReturn($node);
+
+        $this->parse($token)->shouldReturn($node);
+    }
+
+    /**
+     * {% flashes using catalog {expr:catalog} %}
+     *      <div class="flash {{ type }}">{{ message }}</div>
+     * {% endflashes %}
+     */
+    function it_should_parse_flashes_tag_with_no_specified_types_nor_catalog(
+        $parser, $exprParser, $stream, $body, $nodeFactory, $node, $token
+    )
+    {
+        $stream->test(\Twig_Token::NAME_TYPE, 'using')->willReturn(false);
+        $stream->test(\Twig_Token::BLOCK_END_TYPE)->willReturn(true);
+
+        $stream->test(\Twig_Token::NAME_TYPE, 'using')->willReturn(false);
+
+        $stream->expect(\Twig_Token::BLOCK_END_TYPE);
+
+        $parser->subparse(array($this, 'isEndTag'), true)->willReturn($body);
+
+        $stream->expect(\Twig_Token::BLOCK_END_TYPE);
+
+        $nodeFactory->createFlashesNode(null, null, $body, 123)->willReturn($node);
+
+        $this->parse($token)->shouldReturn($node);
+    }
+
+    function its_isEndTag_should_return_true_recognize_end_tag_token($token)
+    {
+        $token->test('endflashes')->willReturn(true);
+
+        $this->isEndTag($token)->shouldReturn(true);
+    }
+
+    function its_isEndTag_should_return_false_otherwise($token)
+    {
+        $token->test('endflashes')->willReturn(false);
+
+        $this->isEndTag($token)->shouldReturn(false);
+    }
+}


### PR DESCRIPTION
This PR tries to normalize the way we handle flash messages. It supports placeholders in messages, translation & pluralization.

The base controller has been updated to use instances of `Knp\RadBundle\Flash\Message` that are suitable for rendering through the `Knp\RadBundle\Flash\MessageRenderer`.

To create a flash message from a controller:

``` php
<?php

    public function fooActon($name = 'World')
    {
        // simple message
        $this->addFlash('success', 'It works!');

        // with some parameters
        $this->addFlash('success', 'Hello {{ name }}!', array(
            '{{ name }}' => $name
        ));

        // with pluralization
        $this->addFlash('success', 'An apple added.|{{ count }} apples added.', array(), $numApples);
    }
```

From a twig template, you can render the flashes using the `flashes` tag:

``` jinja
{# basic exemple #}
{% flashes  %}
    <div class="flash {{ type }}">{{ message }}</div>
{% endflashes %}

{# specifying one type #}
{% flashes "success"  %}
    <div class="flash {{ type }}">{{ message }}</div>
{% endflashes %}


{# specifying an array of types #}
{% flashes ["success", "failure"]  %}
    <div class="flash {{ type }}">{{ message }}</div>
{% endflashes %}
```

By default, all the messages are translated using the `messages` catalog. But you can configure it:

``` yml
knp_rad:
    flashes:
        trans_catalog: flashes
```

or specify it in the `flashes` tag:

``` jinja
{% flashes ["success", "failure"] using catalog "flashes"  %}
    <div class="flash {{ type }}">{{ message }}</div>
{% endflashes %}
```
