### PR TITLE
Provide support for Nelmio\Alice in AbstractFixture

### DIFF
--- a/DataFixtures/AbstractFixture.php
+++ b/DataFixtures/AbstractFixture.php
@@ -4,12 +4,28 @@ namespace Knp\RadBundle\DataFixtures;
 
 use Doctrine\Common\Persistence\ObjectManager;
 use Doctrine\Common\DataFixtures\AbstractFixture as BaseAbstractFixture;
+use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
+
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
-abstract class AbstractFixture extends BaseAbstractFixture implements ContainerAwareInterface
+use Nelmio\Alice\Fixtures;
+
+abstract class AbstractFixture extends BaseAbstractFixture implements ContainerAwareInterface, OrderedFixtureInterface
 {
     protected $container;
+
+    public function load(ObjectManager $manager)
+    {
+        foreach ($this->getAliceFiles() as $files) {
+            Fixtures::load($file, $manager, $this->getAliceOptions());
+        }
+    }
+
+    public function getOrder()
+    {
+        return 1;
+    }
 
     public function createObjectFactory(ObjectManager $manager, $className)
     {
@@ -19,5 +35,17 @@ abstract class AbstractFixture extends BaseAbstractFixture implements ContainerA
     public function setContainer(ContainerInterface $container = null)
     {
         $this->container = $container;
+    }
+
+    protected function getAliceFiles()
+    {
+        return glob(__DIR__.'/*.yml');
+    }
+
+    protected function getAliceOptions()
+    {
+        return array(
+            'providers' => array($this)
+        );
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,10 @@
         }
     ],
     "require": {
-        "php":                               ">=5.3.3",
-        "symfony/framework-bundle":          ">=2.1"
+        "php":                      ">=5.3.3",
+        "symfony/framework-bundle": ">=2.1",
+        "nelmio/alice":             "*",
+        "fzaninotto/faker":         "*"
     },
     "require-dev": {
         "phpspec/phpspec2":                  "dev-develop",


### PR DESCRIPTION
Even more than that, if AbstractFixture::load() is not
overrided, it'll load all `*.yml` files (if exist) from
current fixture directory through Alice.
