### PR TITLE
Mailer message factory

### DIFF
--- a/Controller/Controller.php
+++ b/Controller/Controller.php
@@ -47,12 +47,12 @@ class Controller extends BaseController
         return $this->get('mailer');
     }
 
-    protected function createMessageFor($name, array $parameters)
+    protected function createMessageFor($name, array $parameters = array())
     {
         return $this->get('knp_rad.mailer.message_factory')->createMessage($name, $parameters);
     }
 
-    protected function sendMessage($from, $to, $name, array $parameters)
+    protected function sendMessage($from, $to, $name, array $parameters = array())
     {
         $message = $this->createMessageFor($name, $parameters);
         $message->setTo($to);

--- a/Controller/Controller.php
+++ b/Controller/Controller.php
@@ -47,6 +47,20 @@ class Controller extends BaseController
         return $this->get('mailer');
     }
 
+    protected function createMessageFor($name, array $parameters)
+    {
+        return $this->get('knp_rad.mailer.message_factory')->createMessage($name, $parameters);
+    }
+
+    protected function sendMessage($from, $to, $name, array $parameters)
+    {
+        $message = $this->createMessageFor($name, $parameters);
+        $message->setTo($to);
+        $message->setFrom($from);
+
+        $this->getMailer()->send($message);
+    }
+
     protected function getSession()
     {
         return $this->get('session');

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -22,7 +22,13 @@ class Configuration implements ConfigurationInterface
 
         $rootNode
             ->children()
-                ->booleanNode('mailer_logger')->defaultFalse()->end()
+                ->arrayNode('mailer')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->booleanNode('logger')->defaultFalse()->end()
+                        ->booleanNode('factory')->defaultTrue()->end()
+                    ->end()
+                ->end()
                 ->arrayNode('listener')
                     ->addDefaultsIfNotSet()
                     ->children()

--- a/DependencyInjection/KnpRadExtension.php
+++ b/DependencyInjection/KnpRadExtension.php
@@ -24,8 +24,11 @@ class KnpRadExtension extends Extension
 
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
 
-        if ($config['mailer_logger']) {
+        if ($config['mailer']['logger']) {
             $loader->load('mailer_logger.xml');
+        }
+        if ($config['mailer']['message_factory']) {
+            $loader->load('mailer_message_factory.xml');
         }
 
         if ($config['listener']['view']) {

--- a/Mailer/MessageFactory.php
+++ b/Mailer/MessageFactory.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Knp\RadBundle\Mailer;
+
+use Swift_Mailer;
+use Twig_Environment;
+
+class MessageFactory
+{
+    private $mailer;
+    private $twig;
+
+    public function __construct(Swift_Mailer $mailer, Twig_Environment $twig)
+    {
+        $this->mailer = $mailer;
+        $this->twig   = $twig;
+    }
+
+    public function createMessage($name, array $parameters)
+    {
+        $subject = $txtBody = $htmlBody = null;
+        $txtTpl  = sprintf('App:Mails:%s.txt.twig', $name);
+        $htmlTpl = sprintf('App:Mails:%s.html.twig', $name);
+
+        if (true === $this->twig->getLoader()->exists($txtTpl)) {
+            $template = $this->twig->loadTemplate($txtTpl);
+            $subject  = $template->renderBlock('subject', $parameters);
+            $txtBody  = $template->renderBlock('body', $parameters);
+        }
+
+        if (true === $this->twig->getLoader()->exists($htmlTpl)) {
+            $template = $this->twig->loadTemplate($htmlTpl);
+            $subject  = $subject ?: $template->renderBlock('subject', $parameters);
+            $htmlBody = $template->renderBlock('body', $parameters);
+        }
+
+        if (!$subject) {
+            throw new \Twig_Error_Loader(sprintf(
+                'Can not find mail subject in "%s" or "%s".', $txtTpl, $htmlTpl
+            ));
+        }
+
+        if (!$txtBody && !$htmlBody) {
+            throw new \Twig_Error_Loader(sprintf(
+                'Can not find mail body in "%s" or "%s".', $txtTpl, $htmlTpl
+            ));
+        }
+
+        $message = $this->mailer->createMessage();
+        $message->setSubject($subject);
+
+        if ($txtBody) {
+            $message->setBody($txtBody, 'text/plain');
+        } else {
+            $message->setBody($htmlBody, 'text/html');
+        }
+
+        if ($txtBody && $htmlBody) {
+            $message->addPart($htmlBody, 'text/html');
+        }
+
+        return $message;
+    }
+}

--- a/Resources/config/mailer_message_factory.xml
+++ b/Resources/config/mailer_message_factory.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="knp_rad.mailer.message_factory.class">Knp\RadBundle\Mailer\MessageFactory</parameter>
+    </parameters>
+
+    <services>
+
+        <service id="knp_rad.mailer.message_factory" class="%knp_rad.mailer.message_factory.class%" public="true">
+            <argument type="service" id="mailer" />
+            <argument type="service" id="twig" />
+        </service>
+
+    </services>
+
+</container>

--- a/spec/Mailer/MessageFactory.php
+++ b/spec/Mailer/MessageFactory.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace spec\Knp\RadBundle\Mailer;
+
+use PHPSpec2\ObjectBehavior;
+
+class MessageFactory extends ObjectBehavior
+{
+    /**
+     * @param  Swift_Mailer               $mailer
+     * @param  Twig_Environment           $twig
+     * @param  Twig_ExistsLoaderInterface $loader
+     */
+    function let($mailer, $twig, $loader)
+    {
+        $twig->getLoader()->willReturn($loader);
+
+        $this->beConstructedWith($mailer, $twig);
+    }
+
+    /**
+     * @param  Swift_Mime_Message $message
+     * @param  Twig_Template      $template
+     * @param  stdClass           $subject
+     * @param  stdClass           $body
+     */
+    function it_should_create_a_txt_message_if_only_txt_template_available(
+        $mailer, $twig, $loader, $message, $template, $subject, $body
+    )
+    {
+        $loader->exists('App:Mails:contact_message.txt.twig')->willReturn(true);
+        $twig->loadTemplate('App:Mails:contact_message.txt.twig')->willReturn($template);
+        $loader->exists('App:Mails:contact_message.html.twig')->willReturn(false);
+
+        $template->renderBlock('subject', array('foo' => 'bar'))->willReturn($subject);
+        $template->renderBlock('body', array('foo' => 'bar'))->willReturn($body);
+
+        $mailer->createMessage()->willReturn($message);
+        $message->setSubject($subject)->shouldBeCalled();
+        $message->setBody($body, 'text/plain')->shouldBeCalled();
+
+        $this->createMessage('contact_message', array('foo' => 'bar'))->shouldReturn($message);
+    }
+
+    /**
+     * @param  Swift_Mime_Message $message
+     * @param  Twig_Template      $template
+     * @param  stdClass           $subject
+     * @param  stdClass           $body
+     */
+    function it_should_create_an_html_message_if_only_html_template_available(
+        $mailer, $twig, $loader, $message, $template, $subject, $body
+    )
+    {
+        $loader->exists('App:Mails:contact_message.txt.twig')->willReturn(false);
+        $loader->exists('App:Mails:contact_message.html.twig')->willReturn(true);
+        $twig->loadTemplate('App:Mails:contact_message.html.twig')->willReturn($template);
+
+        $template->renderBlock('subject', array('foo' => 'bar'))->willReturn($subject);
+        $template->renderBlock('body', array('foo' => 'bar'))->willReturn($body);
+
+        $mailer->createMessage()->willReturn($message);
+        $message->setSubject($subject)->shouldBeCalled();
+        $message->setBody($body, 'text/html')->shouldBeCalled();
+
+        $this->createMessage('contact_message', array('foo' => 'bar'))->shouldReturn($message);
+    }
+
+    /**
+     * @param  Swift_Mime_Message $message
+     * @param  Twig_Template      $template1
+     * @param  Twig_Template      $template2
+     * @param  stdClass           $subject1
+     * @param  stdClass           $body1
+     * @param  stdClass           $subject2
+     * @param  stdClass           $body2
+     */
+    function it_should_create_a_multipart_message_if_both_html_and_txt_templates_available(
+        $mailer, $twig, $loader, $message, $template1, $template2, $subject1, $body1, $subject2, $body2
+    )
+    {
+        $loader->exists('App:Mails:contact_message.txt.twig')->willReturn(true);
+        $twig->loadTemplate('App:Mails:contact_message.txt.twig')->willReturn($template1);
+        $loader->exists('App:Mails:contact_message.html.twig')->willReturn(true);
+        $twig->loadTemplate('App:Mails:contact_message.html.twig')->willReturn($template2);
+
+        $template1->renderBlock('subject', array('foo' => 'bar'))->willReturn($subject1);
+        $template1->renderBlock('body', array('foo' => 'bar'))->willReturn($body1);
+
+        $template2->renderBlock('subject', array('foo' => 'bar'))->willReturn($subject2);
+        $template2->renderBlock('body', array('foo' => 'bar'))->willReturn($body2);
+
+        $mailer->createMessage()->willReturn($message);
+        $message->setSubject($subject1)->shouldBeCalled();
+        $message->setBody($body1, 'text/plain')->shouldBeCalled();
+        $message->addPart($body2, 'text/html')->shouldBeCalled();
+
+        $this->createMessage('contact_message', array('foo' => 'bar'))->shouldReturn($message);
+    }
+
+    /**
+     * @param  Swift_Mime_Message $message
+     */
+    function it_should_throw_exception_if_no_template_available(
+        $mailer, $twig, $loader, $message
+    )
+    {
+        $loader->exists('App:Mails:contact_message.txt.twig')->willReturn(false);
+        $loader->exists('App:Mails:contact_message.html.twig')->willReturn(false);
+
+        $this->shouldThrow('Twig_Error_Loader')->duringCreateMessage('contact_message', array());
+    }
+
+    /**
+     * @param  Swift_Mime_Message $message
+     * @param  Twig_Template      $template1
+     * @param  Twig_Template      $template2
+     * @param  stdClass           $subject1
+     * @param  stdClass           $body1
+     * @param  stdClass           $subject2
+     * @param  stdClass           $body2
+     */
+    function it_should_throw_exception_if_both_templates_provide_no_subject_or_body(
+        $mailer, $twig, $loader, $message, $template1, $template2
+    )
+    {
+        $loader->exists('App:Mails:contact_message.txt.twig')->willReturn(true);
+        $twig->loadTemplate('App:Mails:contact_message.txt.twig')->willReturn($template1);
+        $loader->exists('App:Mails:contact_message.html.twig')->willReturn(true);
+        $twig->loadTemplate('App:Mails:contact_message.html.twig')->willReturn($template2);
+
+        $template1->renderBlock('subject', array('foo' => 'bar'))->willReturn(null);
+        $template1->renderBlock('body', array('foo' => 'bar'))->willReturn(null);
+
+        $template2->renderBlock('subject', array('foo' => 'bar'))->willReturn(null);
+        $template2->renderBlock('body', array('foo' => 'bar'))->willReturn(null);
+
+        $this->shouldThrow('Twig_Error_Loader')->duringCreateMessage('contact_message', array(
+            'foo' => 'bar'
+        ));
+    }
+}


### PR DESCRIPTION
Adds shorthand `sendMessage($from, $to, $name, $parameters)` method to the base controller. Where `$from` - sender address, `$to` - recipient address, `$name` is short name of the mail template and `$parameters` are parameters for that template.

If you'll do something like:

``` php
$this->sendMessage('server@knplabs.com', 'everzet@knplabs.com', 'contact');
```

Mailer factory will:
1. Find `App:Mails:contact.txt.twig` template (if exists) and load `subject` & `body` blocks from it as mail body and subject
2. Find `App:Mails:contact.html.twig` template (if exists) and load its `body` into html part of the message (multibody message)
3. Set `from` to "server@knplabs.com"
4. Set `to` to "everzet@knplabs.com"
5. Send an email with current DIC mailer
