### PR TITLE
[WIP] Hardcode app namespace and normalize generated service ids

### DIFF
--- a/DependencyInjection/Compiler/RegisterDoctrineRepositoriesPass.php
+++ b/DependencyInjection/Compiler/RegisterDoctrineRepositoriesPass.php
@@ -28,12 +28,11 @@ class RegisterDoctrineRepositoriesPass implements CompilerPassInterface
     public function process(ContainerBuilder $container)
     {
         $directory = $this->bundle->getPath().'/Entity';
-        $namespace = $this->bundle->getNamespace().'\Entity';
 
-        $classes = $this->classFinder->findClassesMatching($directory, $namespace, '(?<!Repository)$');
+        $classes = $this->classFinder->findClassesMatching($directory, 'App\Entity', '(?<!Repository)$');
 
         foreach ($classes as $class) {
-            $baseClass = substr($class, strlen($namespace) + 1);
+            $baseClass = substr($class, 11);
             $id = sprintf('orm.%s_repository', str_replace('\\', '.', Container::underscore($baseClass)));
 
             if ($container->hasDefinition($id)) {

--- a/DependencyInjection/Compiler/RegisterFormTypesCompilerPass.php
+++ b/DependencyInjection/Compiler/RegisterFormTypesCompilerPass.php
@@ -2,8 +2,6 @@
 
 namespace Knp\RadBundle\DependencyInjection\Compiler;
 
-namespace Knp\RadBundle\DependencyInjection\Compiler;
-
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Knp\RadBundle\Finder\ClassFinder;
@@ -33,13 +31,12 @@ class RegisterFormTypesCompilerPass implements CompilerPassInterface
     public function process(ContainerBuilder $container)
     {
         $directory = $this->bundle->getPath().'/Form';
-        $namespace = $this->bundle->getNamespace().'\\Form';
 
         $types   = $container->getDefinition('form.extension')->getArgument(1);
-        $classes = $this->classFinder->findClassesMatching($directory, $namespace, 'Type$');
+        $classes = $this->classFinder->findClassesMatching($directory, 'App\Form', 'Type$');
 
         foreach ($classes as $class) {
-            $id = $this->serviceIdGenerator->generateForBundleClass($this->bundle, $class);
+            $id = $this->serviceIdGenerator->generateForClassName($class);
             $alias = $this->getAlias($class, $id);
 
             if ($container->hasDefinition($id)) {

--- a/DependencyInjection/Compiler/RegisterSecurityVotersPass.php
+++ b/DependencyInjection/Compiler/RegisterSecurityVotersPass.php
@@ -37,13 +37,11 @@ class RegisterSecurityVotersPass implements CompilerPassInterface
         }
 
         $decisionManagerDef = $container->getDefinition('security.access.decision_manager');
+        $directory          = $this->bundle->getPath().'/Security';
+        $classes            = $this->classFinder->findClassesMatching($directory, 'App\Security', 'Voter$');
 
-        $directory = $this->bundle->getPath().'/Security';
-        $namespace = $this->bundle->getNamespace().'\Security';
-
-        $classes = $this->classFinder->findClassesMatching($directory, $namespace, 'Voter$');
         foreach ($classes as $class) {
-            $id = $this->serviceIdGenerator->generateForBundleClass($this->bundle, $class);
+            $id = $this->serviceIdGenerator->generateForClassName($class);
 
             if ($container->hasDefinition($id)) {
                 continue;

--- a/DependencyInjection/ServiceIdGenerator.php
+++ b/DependencyInjection/ServiceIdGenerator.php
@@ -7,16 +7,11 @@ use Symfony\Component\DependencyInjection\Container;
 
 class ServiceIdGenerator
 {
-    public function generateForBundleClass(BundleInterface $bundle, $className)
+    public function generateForClassName($className)
     {
-        $namespace = $bundle->getNamespace();
-        $extension = $bundle->getContainerExtension();
+        $bundleClass = substr($className, 4);
+        $bundlePart  = str_replace('\\', '.', Container::underscore($bundleClass));
 
-        $extensionAlias = $extension->getAlias();
-
-        $bundleClass = substr($className, strlen($namespace) + 1);
-        $bundlePart = str_replace('\\', '.', Container::underscore($bundleClass));
-
-        return sprintf('%s.%s', $extensionAlias, $bundlePart);
+        return sprintf('app.%s', $bundlePart);
     }
 }

--- a/EventListener/ViewListener.php
+++ b/EventListener/ViewListener.php
@@ -20,7 +20,6 @@ class ViewListener
     private $parser;
     private $engine;
     private $requestManipulator;
-    private $bundleName;
 
     /**
      * Initializes listener.
@@ -38,11 +37,6 @@ class ViewListener
         $this->engine             = $engine;
         $this->missingViewHandler = $missingViewHandler ?: new MissingViewHandler();
         $this->requestManipulator = $requestManipulator ?: new RequestManipulator();
-    }
-
-    public function setAppBundleName($bundleName)
-    {
-        $this->bundleName = $bundleName;
     }
 
     /**
@@ -82,11 +76,6 @@ class ViewListener
         $group = str_replace('\\', '/', $group);
         $view  = preg_replace('/Action$/', '', $method);
 
-        return sprintf('%s:%s:%s.%s.%s', $this->getBundleName(), $group, $view, $format, $this->engine);
-    }
-
-    public function getBundleName()
-    {
-        return $this->bundleName ?: 'App';
+        return sprintf('App:%s:%s.%s.%s', $group, $view, $format, $this->engine);
     }
 }

--- a/spec/DependencyInjection/Compiler/RegisterDoctrineRepositoriesPass.php
+++ b/spec/DependencyInjection/Compiler/RegisterDoctrineRepositoriesPass.php
@@ -7,9 +7,9 @@ use PHPSpec2\ObjectBehavior;
 class RegisterDoctrineRepositoriesPass extends ObjectBehavior
 {
     /**
-     * @param Symfony\Component\HttpKernel\Bundle\BundleInterface $bundle
-     * @param Symfony\Component\DependencyInjection\ContainerBuilder $container
-     * @param Knp\RadBundle\Finder\ClassFinder $classFinder
+     * @param Symfony\Component\HttpKernel\Bundle\BundleInterface                    $bundle
+     * @param Symfony\Component\DependencyInjection\ContainerBuilder                 $container
+     * @param Knp\RadBundle\Finder\ClassFinder                                       $classFinder
      * @param Knp\RadBundle\DependencyInjection\Definition\DoctrineRepositoryFactory $definitionFactory
      */
     function let($bundle, $container, $classFinder, $definitionFactory)
@@ -29,9 +29,11 @@ class RegisterDoctrineRepositoriesPass extends ObjectBehavior
     function it_should_register_a_repository_service_for_all_entities_found_in_the_bundle($container, $bundle, $classFinder, $definitionFactory, $cheeseDef, $customerDef)
     {
         $bundle->getPath()->shouldBeCalled()->willReturn('/my/project/src/App');
-        $bundle->getNamespace()->shouldBeCalled()->willReturn('App');
 
-        $classFinder->findClassesMatching('/my/project/src/App/Entity', 'App\Entity', '(?<!Repository)$')->shouldBeCalled()->willReturn(array('App\Entity\Cheese', 'App\Entity\Customer'));
+        $classFinder->findClassesMatching('/my/project/src/App/Entity', 'App\Entity', '(?<!Repository)$')->shouldBeCalled()->willReturn(array(
+            'App\Entity\Cheese',
+            'App\Entity\Customer',
+        ));
 
         $container->hasDefinition('orm.cheese_repository')->willReturn(false)->shouldBeCalled();
         $container->hasDefinition('orm.customer_repository')->willReturn(false)->shouldBeCalled();
@@ -52,9 +54,11 @@ class RegisterDoctrineRepositoriesPass extends ObjectBehavior
     function it_should_not_register_a_repository_service_if_already_defined($container, $bundle, $classFinder, $definitionFactory, $cheeseDef, $customerDef)
     {
         $bundle->getPath()->shouldBeCalled()->willReturn('/my/project/src/App');
-        $bundle->getNamespace()->shouldBeCalled()->willReturn('App');
 
-        $classFinder->findClassesMatching('/my/project/src/App/Entity', 'App\Entity', '(?<!Repository)$')->shouldBeCalled()->willReturn(array('App\Entity\Cheese', 'App\Entity\Customer'));
+        $classFinder->findClassesMatching('/my/project/src/App/Entity', 'App\Entity', '(?<!Repository)$')->shouldBeCalled()->willReturn(array(
+            'App\Entity\Cheese',
+            'App\Entity\Customer',
+        ));
 
         $container->hasDefinition('orm.cheese_repository')->willReturn(true)->shouldBeCalled();
         $container->hasDefinition('orm.customer_repository')->willReturn(false)->shouldBeCalled();
@@ -74,7 +78,6 @@ class RegisterDoctrineRepositoriesPass extends ObjectBehavior
     function it_should_underscore_camelcased_names($container, $bundle, $classFinder, $definitionFactory, $definition)
     {
         $bundle->getPath()->shouldBeCalled()->willReturn('/my/project/src/App');
-        $bundle->getNamespace()->shouldBeCalled()->willReturn('App');
 
         $classFinder->findClassesMatching('/my/project/src/App/Entity', 'App\Entity', '(?<!Repository)$')->shouldBeCalled()->willReturn(array('App\Entity\CheesePicture'));
         $container->hasDefinition('orm.cheese_picture_repository')->willReturn(false)->shouldBeCalled();
@@ -92,7 +95,6 @@ class RegisterDoctrineRepositoriesPass extends ObjectBehavior
     function it_should_replace_namespace_separatores_by_dots_in_names($container, $bundle, $classFinder, $definitionFactory, $definition)
     {
         $bundle->getPath()->shouldBeCalled()->willReturn('/my/project/src/App');
-        $bundle->getNamespace()->shouldBeCalled()->willReturn('App');
 
         $classFinder->findClassesMatching('/my/project/src/App/Entity', 'App\Entity', '(?<!Repository)$')->shouldBeCalled()->willReturn(array('App\Entity\Cheese\Picture'));
         $container->hasDefinition('orm.cheese.picture_repository')->willReturn(false)->shouldBeCalled();

--- a/spec/DependencyInjection/Compiler/RegisterFormTypesCompilerPass.php
+++ b/spec/DependencyInjection/Compiler/RegisterFormTypesCompilerPass.php
@@ -19,7 +19,6 @@ class RegisterFormTypesCompilerPass extends ObjectBehavior
         $this->beConstructedWith($bundle, $classFinder, $definitionFactory, $servIdGen);
 
         $bundle->getPath()->shouldBeCalled()->willReturn('/my/project/src/App');
-        $bundle->getNamespace()->shouldBeCalled()->willReturn('App');
 
         $classFinder->findClassesMatching('/my/project/src/App/Form', 'App\Form', 'Type$')->shouldBeCalled()->willReturn(array(
             'App\Form\CheeseType',
@@ -27,9 +26,9 @@ class RegisterFormTypesCompilerPass extends ObjectBehavior
             'App\Form\MouseType',
         ));
 
-        $servIdGen->generateForBundleClass($bundle, 'App\Form\CheeseType')->willReturn('app.form.cheese_type');
-        $servIdGen->generateForBundleClass($bundle, 'App\Form\EditCheeseType')->willReturn('app.form.edit_cheese_type');
-        $servIdGen->generateForBundleClass($bundle, 'App\Form\MouseType')->willReturn('app.form.mouse_type');
+        $servIdGen->generateForClassName('App\Form\CheeseType')->willReturn('app.form.cheese_type');
+        $servIdGen->generateForClassName('App\Form\EditCheeseType')->willReturn('app.form.edit_cheese_type');
+        $servIdGen->generateForClassName('App\Form\MouseType')->willReturn('app.form.mouse_type');
 
         $formExtension->getArgument(1)->willReturn(array());
         $container->getDefinition('form.extension')->willReturn($formExtension);

--- a/spec/DependencyInjection/Compiler/RegisterSecurityVotersPass.php
+++ b/spec/DependencyInjection/Compiler/RegisterSecurityVotersPass.php
@@ -20,7 +20,6 @@ class RegisterSecurityVotersPass extends ObjectBehavior
         $this->beConstructedWith($bundle, $classFinder, $definitionFactory, $referenceFactory, $serviceIdGenerator, $definitionManipulator);
 
         $bundle->getPath()->willReturn('/my/project/src/App');
-        $bundle->getNamespace()->willReturn('App');
     }
 
     function it_should_be_a_compiler_pass()
@@ -42,23 +41,23 @@ class RegisterSecurityVotersPass extends ObjectBehavior
 
         $classFinder->findClassesMatching('/my/project/src/App/Security', 'App\Security', 'Voter$')->willReturn(array(
             'App\Security\Voter\CheeseVoter',
-            'App\Security\Voter\CustomerVoter',
+            'App\Security\CustomerVoter',
         ));
 
         $container->hasDefinition('app.security.voter.cheese_voter')->willReturn(false)->shouldBeCalled();
-        $container->hasDefinition('app.security.voter.customer_voter')->willReturn(false)->shouldBeCalled();
+        $container->hasDefinition('app.security.customer_voter')->willReturn(false)->shouldBeCalled();
 
         $definitionFactory->createDefinition('App\Security\Voter\CheeseVoter')->willReturn($cheeseVoterDef);
-        $definitionFactory->createDefinition('App\Security\Voter\CustomerVoter')->willReturn($customerVoterDef);
+        $definitionFactory->createDefinition('App\Security\CustomerVoter')->willReturn($customerVoterDef);
 
-        $serviceIdGenerator->generateForBundleClass($bundle, 'App\Security\Voter\CheeseVoter')->shouldBeCalled()->willReturn('app.security.voter.cheese_voter');
-        $serviceIdGenerator->generateForBundleClass($bundle, 'App\Security\Voter\CustomerVoter')->shouldBeCalled()->willReturn('app.security.voter.customer_voter');
+        $serviceIdGenerator->generateForClassName('App\Security\Voter\CheeseVoter')->shouldBeCalled()->willReturn('app.security.voter.cheese_voter');
+        $serviceIdGenerator->generateForClassName('App\Security\CustomerVoter')->shouldBeCalled()->willReturn('app.security.customer_voter');
 
         $container->setDefinition('app.security.voter.cheese_voter', $cheeseVoterDef)->shouldBeCalled();
-        $container->setDefinition('app.security.voter.customer_voter', $customerVoterDef)->shouldBeCalled();
+        $container->setDefinition('app.security.customer_voter', $customerVoterDef)->shouldBeCalled();
 
         $referenceFactory->createReference('app.security.voter.cheese_voter')->willReturn($cheeseVoterRef);
-        $referenceFactory->createReference('app.security.voter.customer_voter')->willReturn($customerVoterRef);
+        $referenceFactory->createReference('app.security.customer_voter')->willReturn($customerVoterRef);
 
         $definitionManipulator->appendArgumentValue($decisionManagerDef, 0, $cheeseVoterRef)->shouldBeCalled();
         $definitionManipulator->appendArgumentValue($decisionManagerDef, 0, $customerVoterRef)->shouldBeCalled();

--- a/spec/DependencyInjection/ServiceIdGenerator.php
+++ b/spec/DependencyInjection/ServiceIdGenerator.php
@@ -6,21 +6,8 @@ use PHPSpec2\ObjectBehavior;
 
 class ServiceIdGenerator extends ObjectBehavior
 {
-    /**
-     * @param  Symfony\Component\HttpKernel\Bundle\BundleInterface $bundle
-     * @param  Symfony\Component\DependencyInjection\Extension\ExtensionInterface $extension
-     */
-    function let($bundle, $extension)
+    function it_should_generate_a_service_id_for_a_class()
     {
-        $bundle->getNamespace()->willReturn('Knp\BlogBundle');
-
-        $extension->getAlias()->willReturn('knp_blog');
-    }
-
-    function it_should_generate_a_service_id_for_a_bundle_class($bundle, $extension)
-    {
-        $bundle->getContainerExtension()->willReturn($extension);
-
-        $this->generateForBundleClass($bundle, 'Knp\BlogBundle\Rating\ArticleRater')->shouldReturn('knp_blog.rating.article_rater');
+        $this->generateForClassName('App\Rating\ArticleRater')->shouldReturn('app.rating.article_rater');
     }
 }

--- a/spec/EventListener/ViewListener.php
+++ b/spec/EventListener/ViewListener.php
@@ -128,8 +128,6 @@ class ViewListener extends ObjectBehavior
 
     function it_should_deduce_view_with_correct_bundle_name($request, $response, $reqManip, $engine, $event, $cnp, $mvh)
     {
-        $this->setAppBundleName('TestBundle');
-
         $reqManip->hasAttribute($request, '_controller')->willReturn(true);
         $reqManip->getAttribute($request, '_controller')->willReturn('App\Controller\CheeseController::eatAction');
 
@@ -137,9 +135,9 @@ class ViewListener extends ObjectBehavior
 
         $event->getControllerResult()->willReturn(array('foo' => 'bar'));
 
-        $engine->exists('TestBundle:Cheese:eat.html.twig')->willReturn(false);
+        $engine->exists('App:Cheese:eat.html.twig')->willReturn(false);
 
-        $mvh->handleMissingView($event, 'TestBundle:Cheese:eat.html.twig', array('foo' => 'bar'))->shouldBeCalled();
+        $mvh->handleMissingView($event, 'App:Cheese:eat.html.twig', array('foo' => 'bar'))->shouldBeCalled();
 
         $this->onKernelView($event);
     }


### PR DESCRIPTION
- [ ] Hardcode app namespaces in all parts of the rad bundle
- [ ] Normalize generated services ids

Generated services:

| Service | Class | Service Id |
| --- | --- | --- |
| Security Voter | `App\Security\Voter\UserVoter` | `app.security.voter.user_voter` |
| Entity Repository | `App\Entity\UserRepository` | `orm.user_repository` |
| Form Type | `App\Form\UserType` | `app.form.user_type` |
