### PR TITLE
Added configuration for the decision_manager service id

### DIFF
--- a/DependencyInjection/Compiler/RegisterSecurityVotersPass.php
+++ b/DependencyInjection/Compiler/RegisterSecurityVotersPass.php
@@ -32,11 +32,13 @@ class RegisterSecurityVotersPass implements CompilerPassInterface
 
     public function process(ContainerBuilder $container)
     {
-        if (false === $container->hasDefinition('security.access.decision_manager')) {
+        $decisionManagerId = $container->getParameter('knp_rad.decision_manager.id');
+
+        if (false === $container->hasDefinition($decisionManagerId)) {
             return;
         }
 
-        $decisionManagerDef = $container->getDefinition('security.access.decision_manager');
+        $decisionManagerDef = $container->getDefinition($decisionManagerId);
 
         $directory = $this->bundle->getPath().'/Security';
         $namespace = $this->bundle->getNamespace().'\Security';

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -54,6 +54,12 @@ class Configuration implements ConfigurationInterface
                         ->booleanNode('enabled')->defaultFalse()->end()
                         ->scalarNode('intention')->defaultValue('link')->end()
                     ->end()
+                ->end()
+                ->arrayNode('security')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->scalarNode('decision_manager')->defaultValue('security.access.decision_manager')->end()
+                    ->end()
             ->end()
         ;
 

--- a/DependencyInjection/KnpRadExtension.php
+++ b/DependencyInjection/KnpRadExtension.php
@@ -65,5 +65,6 @@ class KnpRadExtension extends Extension
         if ($config['flashes']['enabled']) {
             $loader->load('flashes.xml');
         }
+        $container->setParameter('knp_rad.decision_manager.id', $config['security']['decision_manager']);
     }
 }

--- a/spec/DependencyInjection/Compiler/RegisterSecurityVotersPass.php
+++ b/spec/DependencyInjection/Compiler/RegisterSecurityVotersPass.php
@@ -37,6 +37,7 @@ class RegisterSecurityVotersPass extends ObjectBehavior
      */
     function it_should_register_security_voters_found_in_the_bundle($bundle, $container, $classFinder, $definitionFactory, $serviceIdGenerator, $referenceFactory, $definitionManipulator, $decisionManagerDef, $cheeseVoterDef, $customerVoterDef, $cheeseVoterRef, $customerVoterRef)
     {
+        $container->getParameter('knp_rad.decision_manager.id')->willReturn('security.access.decision_manager');
         $container->hasDefinition('security.access.decision_manager')->willReturn(true);
         $container->getDefinition('security.access.decision_manager')->willReturn($decisionManagerDef);
 
@@ -84,6 +85,7 @@ class RegisterSecurityVotersPass extends ObjectBehavior
      */
     function it_should_not_register_security_voters_that_do_not_implement_correct_interface($bundle, $container, $classFinder, $definitionFactory, $serviceIdGenerator, $referenceFactory, $definitionManipulator, $decisionManagerDef, $customerVoterDef, $customerVoterRef)
     {
+        $container->getParameter('knp_rad.decision_manager.id')->willReturn('security.access.decision_manager');
         $container->hasDefinition('security.access.decision_manager')->willReturn(true);
         $container->getDefinition('security.access.decision_manager')->willReturn($decisionManagerDef);
 
@@ -115,9 +117,47 @@ class RegisterSecurityVotersPass extends ObjectBehavior
 
     function it_should_abort_processing_when_decision_manager_is_not_defined($container, $classFinder)
     {
+        $container->getParameter('knp_rad.decision_manager.id')->willReturn('security.access.decision_manager');
         $container->hasDefinition('security.access.decision_manager')->willReturn(false);
         $container->getDefinition('security.access.decision_manager')->shouldNotBeCalled();
         $classFinder->findClassesMatching(ANY_ARGUMENTS)->shouldNotBeCalled();
+
+        $this->process($container);
+    }
+
+    /**
+     * @param  Symfony\Component\DependencyInjection\Definition $decisionManagerDef
+     * @param  Symfony\Component\DependencyInjection\Definition $customerVoterDef
+     * @param  Symfony\Component\DependencyInjection\Reference $customerVoterRef
+     */
+    function it_should_use_configured_decision_manager($bundle, $container, $classFinder, $definitionFactory, $serviceIdGenerator, $referenceFactory, $definitionManipulator, $decisionManagerDef, $customerVoterDef, $customerVoterRef)
+    {
+        $container->getParameter('knp_rad.decision_manager.id')->willReturn('security.access.decision_manager.delegate');
+        $container->hasDefinition('security.access.decision_manager.delegate')->willReturn(true);
+        $container->getDefinition('security.access.decision_manager.delegate')->willReturn($decisionManagerDef);
+
+        $classes = array(
+            'App\Security\Voter\CheeseVoter',
+            'App\Security\Voter\CustomerVoter',
+        );
+
+        $classFinder->findClassesMatching('/my/project/src/App/Security', 'App\Security', 'Voter$')->willReturn($classes);
+
+        $classFinder->filterClassesImplementing($classes, 'Symfony\Component\Security\Core\Authorization\Voter\VoterInterface')
+            ->willReturn(array(
+                'App\Security\Voter\CustomerVoter',
+            )
+        );
+
+        $container->hasDefinition('app.security.voter.cheese_voter')->shouldNotBeCalled();
+        $container->hasDefinition('app.security.voter.customer_voter')->shouldBeCalled();
+
+        $definitionFactory->createDefinition('App\Security\Voter\CustomerVoter')->willReturn($customerVoterDef);
+
+        $serviceIdGenerator->generateForBundleClass($bundle, 'App\Security\Voter\CustomerVoter')->shouldBeCalled()->willReturn('app.security.voter.customer_voter');
+        $container->setDefinition('app.security.voter.customer_voter', $customerVoterDef)->shouldBeCalled();
+        $referenceFactory->createReference('app.security.voter.customer_voter')->willReturn($customerVoterRef);
+        $definitionManipulator->appendArgumentValue($decisionManagerDef, 0, $customerVoterRef)->shouldBeCalled();
 
         $this->process($container);
     }


### PR DESCRIPTION
As https://github.com/KnpLabs/KnpRadBundle/pull/62, this PR addresses https://github.com/KnpLabs/KnpRadBundle/issues/61 but brings more flexibility as it lets the user define the decision_manager service id.

When using the `JMSSecurityExtraBundle`:

``` yaml
knp_rad:
    security:
        decision_manager: security.access.decision_manager.delegate
```
