### PR TITLE
Feature/owner security voter

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -40,6 +40,7 @@ class Configuration implements ConfigurationInterface
                 ->end()
                 ->booleanNode('routing_loader')->defaultTrue()->end()
                 ->booleanNode('form_manager')->defaultTrue()->end()
+                ->booleanNode('security_voter')->defaultTrue()->end()
                 ->booleanNode('datatable')->defaultTrue()->end()
                 ->arrayNode('flashes')
                     ->addDefaultsIfNotSet()

--- a/DependencyInjection/KnpRadExtension.php
+++ b/DependencyInjection/KnpRadExtension.php
@@ -30,7 +30,6 @@ class KnpRadExtension extends Extension
         if ($config['mailer']['message_factory']) {
             $loader->load('mailer_message_factory.xml');
         }
-
         if ($config['listener']['view']) {
             $loader->load('view_listener.xml');
         }
@@ -43,24 +42,22 @@ class KnpRadExtension extends Extension
         if ($config['listener']['exception_rethrow']) {
             $loader->load('exception_rethrow_listener.xml');
         }
-
         if ($config['routing_loader']) {
             $loader->load('routing_loader.xml');
         }
-
         if ($config['form_manager']) {
             $loader->load('form_manager.xml');
         }
-
+        if ($config['security_voter']) {
+            $loader->load('security_voter.xml');
+        }
         if ($config['datatable']) {
             $loader->load('datatable.xml');
         }
-
         $container->setParameter('knp_rad.csrf_link.intention', $config['csrf_links']['intention']);
         if ($config['csrf_links']['enabled']) {
             $loader->load('link_attributes.xml');
         }
-
         $container->setParameter('knp_rad.flashes.trans_catalog', $config['flashes']['trans_catalog']);
         if ($config['flashes']['enabled']) {
             $loader->load('flashes.xml');

--- a/Resources/config/security_voter.xml
+++ b/Resources/config/security_voter.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="knp_rad.security.voter.is_owner.class">Knp\RadBundle\Security\Voter\IsOwnerVoter</parameter>
+    </parameters>
+
+    <services>
+
+        <service id="knp_rad.security.voter.is_owner" class="%knp_rad.security.voter.is_owner.class%">
+            <tag name="security.voter" />
+        </service>
+    </services>
+
+</container>

--- a/Security/OwnableInterface.php
+++ b/Security/OwnableInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Knp\RadBundle\Security;
+
+interface OwnableInterface
+{
+    function getOwner();
+}
+

--- a/Security/OwnerInterface.php
+++ b/Security/OwnerInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Knp\RadBundle\Security;
+
+interface OwnerInterface
+{
+}
+

--- a/Security/Voter/IsOwnerVoter.php
+++ b/Security/Voter/IsOwnerVoter.php
@@ -17,9 +17,13 @@ class IsOwnerVoter implements VoterInterface
 
     public function supportsClass($class)
     {
-        $refl = new \ReflectionClass($class);
+        if (is_object($class)) {
+            $refl = new \ReflectionObject($class);
 
-        return $refl->implementsInterface('Knp\RadBundle\Security\OwnableInterface');
+            return $refl->implementsInterface('Knp\RadBundle\Security\OwnableInterface');
+        }
+
+        return false;
     }
 
     public function vote(TokenInterface $token, $object, array $attributes)
@@ -29,12 +33,12 @@ class IsOwnerVoter implements VoterInterface
                 continue;
             }
 
-            if (!$this->supportsClass(get_class($object))) {
-                return self::ACCESS_DENIED;
+            if (!$this->supportsClass($object)) {
+                return self::ACCESS_ABSTAIN;
             }
 
             if (!$token->getUser() instanceof OwnerInterface) {
-                return self::ACCESS_DENIED;
+                return self::ACCESS_ABSTAIN;
             }
 
             if ($object->getOwner() === $token->getUser()) {

--- a/Security/Voter/IsOwnerVoter.php
+++ b/Security/Voter/IsOwnerVoter.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Knp\RadBundle\Security\Voter;
+
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Knp\RadBundle\Security\OwnerInterface;
+
+class IsOwnerVoter implements VoterInterface
+{
+    const IS_OWNER = 'IS_OWNER';
+
+    public function supportsAttribute($attribute)
+    {
+        return self::IS_OWNER === $attribute;
+    }
+
+    public function supportsClass($class)
+    {
+        $refl = new \ReflectionClass($class);
+
+        return $refl->implementsInterface('Knp\RadBundle\Security\OwnableInterface');
+    }
+
+    public function vote(TokenInterface $token, $object, array $attributes)
+    {
+        foreach ($attributes as $attribute) {
+            if (!$this->supportsAttribute($attribute)) {
+                continue;
+            }
+
+            if (!$this->supportsClass(get_class($object))) {
+                return self::ACCESS_DENIED;
+            }
+
+            if (!$token->getUser() instanceof OwnerInterface) {
+                return self::ACCESS_DENIED;
+            }
+
+            if ($object->getOwner() === $token->getUser()) {
+                return self::ACCESS_GRANTED;
+            }
+
+            return self::ACCESS_DENIED;
+        }
+
+        return self::ACCESS_ABSTAIN;
+    }
+}

--- a/Security/Voter/IsOwnerVoter.php
+++ b/Security/Voter/IsOwnerVoter.php
@@ -4,7 +4,10 @@ namespace Knp\RadBundle\Security\Voter;
 
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\User\EquatableInterface;
 use Knp\RadBundle\Security\OwnerInterface;
+use Knp\RadBundle\Security\OwnableInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
 
 class IsOwnerVoter implements VoterInterface
 {
@@ -41,7 +44,7 @@ class IsOwnerVoter implements VoterInterface
                 return self::ACCESS_ABSTAIN;
             }
 
-            if ($object->getOwner() === $token->getUser()) {
+            if ($this->isOwner($token->getUser(), $object)) {
                 return self::ACCESS_GRANTED;
             }
 
@@ -49,5 +52,14 @@ class IsOwnerVoter implements VoterInterface
         }
 
         return self::ACCESS_ABSTAIN;
+    }
+
+    private function isOwner(OwnerInterface $owner, OwnableInterface $ownable)
+    {
+        if ($ownable->getOwner() instanceof UserInterface && $owner instanceof EquatableInterface) {
+            return $owner->isEqualTo($ownable->getOwner());
+        }
+
+        return $ownable->getOwner() === $owner;
     }
 }

--- a/spec/Security/Voter/IsOwnerVoter.php
+++ b/spec/Security/Voter/IsOwnerVoter.php
@@ -74,7 +74,7 @@ class IsOwnerVoter extends ObjectBehavior
      * @param Knp\RadBundle\Security\OwnerInterface   $user
      * @param Knp\RadBundle\Security\OwnableInterface $object
      **/
-    function it_should_abstain_to_vote_for_unkown_attribute($token, $user, $object)
+    function it_should_abstain_to_vote_for_unknown_attribute($token, $user, $object)
     {
         $token->getUser()->willReturn($user);
         $object->getOwner()->willReturn($user);

--- a/spec/Security/Voter/IsOwnerVoter.php
+++ b/spec/Security/Voter/IsOwnerVoter.php
@@ -80,4 +80,74 @@ class IsOwnerVoter extends ObjectBehavior
         $object->getOwner()->willReturn($user);
         $this->vote($token, $object, array('IS_TEST'))->shouldReturn(VoterInterface::ACCESS_ABSTAIN);
     }
+
+    /**
+     * @param Knp\RadBundle\Security\OwnableInterface $object
+     * @param Symfony\Component\Security\Core\User\UserInterface $equatableUser
+     * @param Knp\RadBundle\Security\OwnerInterface,Symfony\Component\Security\Core\User\EquatableInterface $user
+     **/
+    function it_should_vote_yes_for_equal_owners($token, $user, $object, $equatableUser)
+    {
+        $token->getUser()->willReturn($user);
+        $object->getOwner()->willReturn($equatableUser);
+        $user->isEqualTo($equatableUser->getWrappedSubject())->willReturn(true);
+
+        $this->vote($token, $object, array('IS_OWNER'))->shouldReturn(VoterInterface::ACCESS_GRANTED);
+    }
+
+    /**
+     * @param Knp\RadBundle\Security\OwnableInterface $object
+     * @param Symfony\Component\Security\Core\User\UserInterface $equatableUser
+     * @param Knp\RadBundle\Security\OwnerInterface,Symfony\Component\Security\Core\User\EquatableInterface $user
+     **/
+    function it_should_vote_no_for_non_equal_owners($token, $user, $object, $equatableUser)
+    {
+        $token->getUser()->willReturn($user);
+        $object->getOwner()->willReturn($equatableUser);
+        $user->isEqualTo($equatableUser->getWrappedSubject())->willReturn(false);
+
+        $this->vote($token, $object, array('IS_OWNER'))->shouldReturn(VoterInterface::ACCESS_DENIED);
+    }
+
+    /**
+     * @param Knp\RadBundle\Security\OwnableInterface $object
+     * @param Symfony\Component\Security\Core\User\UserInterface $equatableUser
+     * @param Knp\RadBundle\Security\OwnerInterface,Symfony\Component\Security\Core\User\EquatableInterface $user
+     **/
+    function it_should_use_isEqualTo_if_possible($token, $user, $object, $equatableUser)
+    {
+        $token->getUser()->willReturn($user);
+        $object->getOwner()->willReturn($equatableUser);
+        $user->isEqualTo($equatableUser->getWrappedSubject())->shouldBeCalled();
+
+        $this->vote($token, $object, array('IS_OWNER'))->shouldReturn(VoterInterface::ACCESS_DENIED);
+    }
+
+    /**
+     * @param Knp\RadBundle\Security\OwnableInterface $object
+     * @param Knp\RadBundle\Security\OwnerInterface $nonEquatableUser
+     * @param Knp\RadBundle\Security\OwnerInterface,Symfony\Component\Security\Core\User\EquatableInterface $user
+     **/
+    function it_should_not_use_isEqualTo_if_no_UserInterface($token, $user, $object, $nonEquatableUser)
+    {
+        $token->getUser()->willReturn($user);
+        $object->getOwner()->willReturn($nonEquatableUser);
+        $user->isEqualTo($nonEquatableUser)->shouldNotBeCalled();
+
+        $this->vote($token, $object, array('IS_OWNER'))->shouldReturn(VoterInterface::ACCESS_DENIED);
+    }
+
+    /**
+     * @param Knp\RadBundle\Security\OwnableInterface $object
+     * @param Symfony\Component\Security\Core\User\UserInterface $equatableUser
+     * @param Knp\RadBundle\Security\OwnerInterface $user
+     **/
+    function it_should_not_use_isEqualTo_if_no_EquatableInterface($token, $user, $object, $equatableUser)
+    {
+        $token->getUser()->willReturn($user);
+        $object->getOwner()->willReturn($equatableUser);
+        $user->isEqualTo($equatableUser)->shouldNotBeCalled();
+
+        $this->vote($token, $object, array('IS_OWNER'))->shouldReturn(VoterInterface::ACCESS_DENIED);
+    }
 }

--- a/spec/Security/Voter/IsOwnerVoter.php
+++ b/spec/Security/Voter/IsOwnerVoter.php
@@ -52,22 +52,22 @@ class IsOwnerVoter extends ObjectBehavior
      * @param Knp\RadBundle\Security\OwnerInterface   $user
      * @param stdClass $object
      **/
-    function it_should_vote_no_for_not_ownable_object($token, $user, $object)
+    function it_should_abstain_to_vote_for_not_ownable_object($token, $user, $object)
     {
         $token->getUser()->willReturn($user);
         $object->getOwner()->willReturn($user);
-        $this->vote($token, $object, array('IS_OWNER'))->shouldReturn(VoterInterface::ACCESS_DENIED);
+        $this->vote($token, $object, array('IS_OWNER'))->shouldReturn(VoterInterface::ACCESS_ABSTAIN);
     }
 
     /**
      * @param stdClass  $user
      * @param Knp\RadBundle\Security\OwnableInterface $object
      **/
-    function it_should_vote_no_for_not_owner_token_user($token, $user, $object)
+    function it_should_abstain_to_vote_for_not_owner_token_user($token, $user, $object)
     {
         $token->getUser()->willReturn($user);
         $object->getOwner()->willReturn($user);
-        $this->vote($token, $object, array('IS_OWNER'))->shouldReturn(VoterInterface::ACCESS_DENIED);
+        $this->vote($token, $object, array('IS_OWNER'))->shouldReturn(VoterInterface::ACCESS_ABSTAIN);
     }
 
     /**

--- a/spec/Security/Voter/IsOwnerVoter.php
+++ b/spec/Security/Voter/IsOwnerVoter.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace spec\Knp\RadBundle\Security\Voter;
+
+use PHPSpec2\ObjectBehavior;
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+
+class IsOwnerVoter extends ObjectBehavior
+{
+    /**
+     * @param \Symfony\Component\Security\Core\Authentication\Token\TokenInterface $token
+     **/
+    function let()
+    {
+    }
+
+    function it_should_be_initializable()
+    {
+        $this->shouldHaveType('Knp\RadBundle\Security\Voter\IsOwnerVoter');
+    }
+
+    function it_should_only_support_IS_OWNER_attribute()
+    {
+        $this->supportsAttribute('IS_OWNER')->shouldReturn(true);
+        $this->supportsAttribute('IS_SOMETHING_ELSE')->shouldReturn(false);
+    }
+
+    /**
+     * @param Knp\RadBundle\Security\OwnerInterface   $user
+     * @param Knp\RadBundle\Security\OwnableInterface $object
+     **/
+    function it_should_vote_yes_for_owned_object($token, $user, $object)
+    {
+        $token->getUser()->willReturn($user);
+        $object->getOwner()->willReturn($user);
+        $this->vote($token, $object, array('IS_OWNER'))->shouldReturn(VoterInterface::ACCESS_GRANTED);
+    }
+
+    /**
+     * @param Knp\RadBundle\Security\OwnerInterface   $user
+     * @param Knp\RadBundle\Security\OwnerInterface   $otherUser
+     * @param Knp\RadBundle\Security\OwnableInterface $object
+     **/
+    function it_should_vote_no_for_not_owned_object($token, $user, $otherUser, $object)
+    {
+        $token->getUser()->willReturn($user);
+        $object->getOwner()->willReturn($otherUser);
+        $this->vote($token, $object, array('IS_OWNER'))->shouldReturn(VoterInterface::ACCESS_DENIED);
+    }
+
+    /**
+     * @param Knp\RadBundle\Security\OwnerInterface   $user
+     * @param stdClass $object
+     **/
+    function it_should_vote_no_for_not_ownable_object($token, $user, $object)
+    {
+        $token->getUser()->willReturn($user);
+        $object->getOwner()->willReturn($user);
+        $this->vote($token, $object, array('IS_OWNER'))->shouldReturn(VoterInterface::ACCESS_DENIED);
+    }
+
+    /**
+     * @param stdClass  $user
+     * @param Knp\RadBundle\Security\OwnableInterface $object
+     **/
+    function it_should_vote_no_for_not_owner_token_user($token, $user, $object)
+    {
+        $token->getUser()->willReturn($user);
+        $object->getOwner()->willReturn($user);
+        $this->vote($token, $object, array('IS_OWNER'))->shouldReturn(VoterInterface::ACCESS_DENIED);
+    }
+
+    /**
+     * @param Knp\RadBundle\Security\OwnerInterface   $user
+     * @param Knp\RadBundle\Security\OwnableInterface $object
+     **/
+    function it_should_abstain_to_vote_for_unkown_attribute($token, $user, $object)
+    {
+        $token->getUser()->willReturn($user);
+        $object->getOwner()->willReturn($user);
+        $this->vote($token, $object, array('IS_TEST'))->shouldReturn(VoterInterface::ACCESS_ABSTAIN);
+    }
+}


### PR DESCRIPTION
Permits to use the decision manager system to check if an object implementing `OwnableInterface` is owned by an object implementing `OwnerInterface`.

If object implementing `OwnerInterface` also implements `EquatableInterface` and `UserInterface`, it will be used to check equality of owner.

``` php

class Post implements OwnableInterface
{
    /**
     * @ORM\ManyToOne(targetEntity="User")
     **/
    public $createdBy;

    public function getOwner()
    {
        return $this->createdBy;
    }
}

class User implements OwnerInterface, UserInterface, EquatableInterface
{
}


$securityContext->isGranted('IS_OWNER', new Post); // true if Post::createdBy is current logged in user

```
