### PR TITLE
Make rad entity repository concrete

### DIFF
--- a/Doctrine/EntityRepository.php
+++ b/Doctrine/EntityRepository.php
@@ -5,7 +5,7 @@ namespace Knp\RadBundle\Doctrine;
 use Doctrine\ORM\EntityRepository as BaseEntityRepository;
 use Doctrine\ORM\QueryBuilder;
 
-abstract class EntityRepository extends BaseEntityRepository
+class EntityRepository extends BaseEntityRepository
 {
     public function __call($method, $arguments)
     {


### PR DESCRIPTION
As from KnpLabs/rad-edition@759bcc44ca1ec5a13c7dbf8727d8edd587c35e46
Rad EntityRepository is the default one, it needs to be concrete or the
EntityManager won't be able to instanciate it when the user do not use
a concrete custom repository.

See
https://github.com/doctrine/doctrine2/blob/2.3.2/lib/Doctrine/ORM/EntityManager.php#L689
