### PR TITLE
Use the flashes tag in the twitter bootstrap layout

### DIFF
--- a/Resources/views/Layout/tb.html.twig
+++ b/Resources/views/Layout/tb.html.twig
@@ -11,14 +11,12 @@
 {% endblock %}
 
 {% block flashes %}
-    <div class="knprad-flashes" style="position:absolute;width:500px;z-index:1000;left:50%;margin-left:-250px;top:10px;">
-    {% for name, flash in app.session.flashes %}
-        <div class="alert alert-block alert-{{ name }}">
-            <button type="button" class="close" data-dismiss="alert">×</button>
-            {{ flash.message|default(flash)|trans(flash.parameters|default({}))|raw }}
+    {% flashes %}
+        <div class="alert alert-{{ type }}">
+            <button type="button" class="close" data-dismiss="alert">&times;</button>
+            {{ message }}
         </div>
-    {% endfor %}
-    </div>
+    {% endflashes %}
 {% endblock %}
 
 {% block body %}


### PR DESCRIPTION
First, it removes the deprecated warning due to the Session::getFlashes() call.
Second, it'll work, as the flashes extension is enabled by default!

Related to https://github.com/KnpLabs/KnpRadBundle/issues/69
