### PR TITLE
Return one or null result when calling repository method containing 'one'

### DIFF
--- a/Doctrine/EntityRepository.php
+++ b/Doctrine/EntityRepository.php
@@ -14,6 +14,10 @@ class EntityRepository extends BaseEntityRepository
             if (method_exists($this, $builder = 'build'.substr($method, 4))) {
                 $qb = call_user_func_array(array($this, $builder), $arguments);
 
+                if (0 === strpos(substr($method, 4), 'One')) {
+                    return $qb->getQuery()->getOneOrNullResult();
+                }
+
                 return $qb->getQuery()->getResult();
             }
         }

--- a/spec/tests/fixtures/RADRepository.php
+++ b/spec/tests/fixtures/RADRepository.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace spec\Knp\RadBundle\tests\fixtures;
+
+use PHPSpec2\ObjectBehavior;
+use Doctrine\ORM\NonUniqueResultException;
+
+class RADRepository extends ObjectBehavior
+{
+    /**
+     * @param Doctrine\ORM\EntityManager         $em
+     * @param Doctrine\ORM\Mapping\ClassMetadata $class
+     * @param Doctrine\ORM\QueryBuilder          $qb
+     * @param Doctrine\ORM\AbstractQuery         $query
+     */
+    function let($em, $class, $qb, $query)
+    {
+        $em->createQueryBuilder()->willReturn($qb);
+        $qb->select(ANY_ARGUMENT)->willReturn($qb);
+        $qb->from(ANY_ARGUMENTS)->willReturn($qb);
+        $qb->where('rad.foo = bar')->willReturn($qb);
+        $class->name = 'rad';
+        $qb->getQuery()->willReturn($query);
+
+        $this->beConstructedWith($em, $class);
+    }
+
+    function it_should_be_a_rad_entity_repository()
+    {
+        $this->shouldHaveType('Knp\RadBundle\Doctrine\EntityRepository');
+    }
+
+    function it_should_find_all_valid_entities($qb, $query)
+    {
+        $query->getResult()->willReturn(['foo', 'bar']);
+
+        $this->findValid()->shouldReturn(['foo', 'bar']);
+    }
+
+    function it_should_find_only_one_result_when_method_contains_One($qb, $query)
+    {
+        $qb->where('rad.id = 1')->willReturn($qb);
+        $query->getOneOrNullResult()->willReturn('foo');
+        $query->getResult()->shouldNotBeCalled();
+
+        $this->findOneValid(1)->shouldReturn('foo');
+    }
+
+    function it_should_throw_non_unique_result_exception_when_finding_one_entity_and_multiple_results_were_found($qb, $query)
+    {
+        $qb->where('rad.id = 1')->willReturn($qb);
+        $query->getOneOrNullResult()->willThrow(new NonUniqueResultException);
+
+        $this->shouldThrow(new NonUniqueResultException)->duringFindOneValid(1);
+    }
+}

--- a/tests/fixtures/RADRepository.php
+++ b/tests/fixtures/RADRepository.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Knp\RadBundle\tests\fixtures;
+
+use Knp\RadBundle\Doctrine\EntityRepository;
+
+class RADRepository extends EntityRepository
+{
+    public function buildValid()
+    {
+        return $this
+            ->build()
+            ->where($this->getAlias().'.foo = bar')
+        ;
+    }
+
+    public function buildOneValid($id)
+    {
+        return $this
+            ->buildOne($id)
+            ->where($this->getAlias().'.foo = bar')
+        ;
+    }
+}


### PR DESCRIPTION
This PR will allow any call to `$repo->findOneValid()` to call `Repo::buildOneValid()` and to return one or null result (and not an array).

Whereas `$repo->findValid()` will still call `Repo::buildValid()` and return an array.
