### PR TITLE
Use configuration to add container parameters

### DIFF
--- a/AppBundle/ContainerExtension.php
+++ b/AppBundle/ContainerExtension.php
@@ -54,5 +54,11 @@ class ContainerExtension extends Extension
                 $container->addResource(new DirectoryResource($dirPath));
             }
         }
+
+        foreach ($configs as $config) {
+            foreach ($config as $name => $value) {
+                $container->setParameter(sprintf('%s.%s', $this->getAlias(), $name), $value);
+            }
+        }
     }
 }

--- a/spec/AppBundle/ContainerExtension.php
+++ b/spec/AppBundle/ContainerExtension.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace spec\Knp\RadBundle\AppBundle;
+
+use PHPSpec2\ObjectBehavior;
+
+class ContainerExtension extends ObjectBehavior
+{
+    function let()
+    {
+        $this->beConstructedWith('my_app');
+    }
+
+    function it_should_be_aliased_app()
+    {
+        $this->getAlias()->shouldReturn('app');
+    }
+
+    /**
+     * @param Symfony\Component\DependencyInjection\ContainerBuilder $container
+     */
+    function it_should_add_configuration_as_container_parameters($container)
+    {
+        $container->getParameter('kernel.environment')->willReturn('dev');
+        $container->setParameter('app.foo', 'bar')->shouldBeCalled();
+        $container->setParameter('app.baz', ['boz' => 'for'])->shouldBeCalled();
+
+        $this->load([[
+            'foo' => 'bar',
+            'baz' => ['boz' => 'for']
+        ]], $container);
+    }
+}

--- a/spec/AppBundle/ContainerExtension.php
+++ b/spec/AppBundle/ContainerExtension.php
@@ -23,11 +23,11 @@ class ContainerExtension extends ObjectBehavior
     {
         $container->getParameter('kernel.environment')->willReturn('dev');
         $container->setParameter('app.foo', 'bar')->shouldBeCalled();
-        $container->setParameter('app.baz', ['boz' => 'for'])->shouldBeCalled();
+        $container->setParameter('app.baz', array('boz' => 'for'))->shouldBeCalled();
 
-        $this->load([[
+        $this->load(array(array(
             'foo' => 'bar',
-            'baz' => ['boz' => 'for']
-        ]], $container);
+            'baz' => array('boz' => 'for')
+        )), $container);
     }
 }

--- a/spec/tests/fixtures/RADRepository.php
+++ b/spec/tests/fixtures/RADRepository.php
@@ -32,9 +32,9 @@ class RADRepository extends ObjectBehavior
 
     function it_should_find_all_valid_entities($qb, $query)
     {
-        $query->getResult()->willReturn(['foo', 'bar']);
+        $query->getResult()->willReturn(array('foo', 'bar'));
 
-        $this->findValid()->shouldReturn(['foo', 'bar']);
+        $this->findValid()->shouldReturn(array('foo', 'bar'));
     }
 
     function it_should_find_only_one_result_when_method_contains_One($qb, $query)


### PR DESCRIPTION
Otherwise the following definition

``` yaml
app:
    foo: bar

services:
    app.foo_manager
        arguments:
            - "%app.foo%"
```

will throw

```
  [Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException]
  The service "app.foo_manager" has a dependency on a non-existent parameter "app.foo".
```
