### PR TITLE
Added project type to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "knplabs/rad-bundle",
     "description": "The \"KnpLabs Rad Edition\" bundle",
+    "type": "project",
     "license":     "MIT",
     "homepage": "http://rad.knplabs.com",
     "authors": [


### PR DESCRIPTION
Some IDE plugins like https://github.com/pulse00/Composer-Eclipse-Plugin show filtered composer packages by the type `project` in their project wizards.

This PR will make the Knp Rad edition show up in these dialogs.
