### PR TITLE
Handle bubbling event properly

### DIFF
--- a/Resources/public/js/jquery-ujs.js
+++ b/Resources/public/js/jquery-ujs.js
@@ -1,8 +1,8 @@
 (function($, undefined) {
     function confirmDeletion (event) {
-        var needConfirmation = !event.target.hasAttribute('data-no-confirm');
+        var needConfirmation = !event.currentTarget.hasAttribute('data-no-confirm');
 
-        if (needConfirmation && !confirm($(event.target).data('confirm') || 'Are you sure?')) {
+        if (needConfirmation && !confirm($(event.currentTarget).data('confirm') || 'Are you sure?')) {
             return false;
         }
 


### PR DESCRIPTION
This is fix for link_attr problem.

For example:

``` django
<a href="#" {{ link_attr('delete', "my confirm message") }}>
  <img src="http://rad.knplabs.com/images/knp_logo.png" />
</a>
```

In this case, `event.target` is not `<a>` element but `<img>` element. So we'll get default confirm message, "Are you sure?".
So I think you should use `event.currentTarget` instead of `event.target`.
