### PR TITLE
Make repositories smarter

### DIFF
--- a/Doctrine/EntityRepository.php
+++ b/Doctrine/EntityRepository.php
@@ -10,7 +10,7 @@ class EntityRepository extends BaseEntityRepository
 {
     public function __call($method, $arguments)
     {
-        $matches = [];
+        $matches = array();
 
         if (0 === strpos($method, 'find')) {
             if (method_exists($this, $builder = 'build'.substr($method, 4))) {


### PR DESCRIPTION
Hi dudes !

Just a little proposition from @Djeg and me about the entity repositories.

Why not try to make the repository smarter by include the limit in the method call string ?

For exemple, if I want my 15 latests actives orders, I just have to call

``` php
$this->getRepository('App:Order')->find15Actives()
```

The repository :

``` php
class OrderRepository  extends EntityRepository
{
    protected class buildActive()
    {
        return $this->buildAll()->andWhere($this->getAlias() . '.active = 1');
    }
}
```
