### PR TITLE
Refactored the templateExists method of the view listener

### DIFF
--- a/EventListener/ViewListener.php
+++ b/EventListener/ViewListener.php
@@ -86,18 +86,21 @@ class ViewListener
         return sprintf('%s:%s:%s.%s.%s', $this->bundleName, $group, $view, $format, $this->engine);
     }
 
-    public function templateExists($viewName)
+    private function templateExists($template)
     {
-        try {
-            $this->twigEnvironment->loadTemplate($viewName);
-            return true;
+        $loader = $this->twigEnvironment->getLoader();
+        if ($loader instanceof \Twig_ExistsLoaderInterface) {
+            return $loader->exists($template);
         }
-        catch (\Twig_Error_Loader $e) {
-            if (sprintf('Unable to find template "%s".', $viewName) === $e->getMessage()) {
-                return false;
-            }
 
+        try {
+            $loader->getSource($template);
+
+            return true;
+        } catch (\Twig_Error_Loader $e) {
             throw $e;
         }
+
+        return false;
     }
 }

--- a/spec/Knp/RadBundle/EventListener/ViewListenerSpec.php
+++ b/spec/Knp/RadBundle/EventListener/ViewListenerSpec.php
@@ -7,30 +7,32 @@ use PhpSpec\ObjectBehavior;
 class ViewListenerSpec extends ObjectBehavior
 {
     /**
-     * @param Symfony\Component\HttpFoundation\Request $request
-     * @param Symfony\Component\HttpFoundation\Response $response
-     * @param Symfony\Bundle\FrameworkBundle\Templating\EngineInterface $engine
-     * @param Twig_Environment $twig
-     * @param Symfony\Bundle\FrameworkBundle\Controller\ControllerNameParser $cnp
-     * @param Knp\RadBundle\HttpFoundation\RequestManipulator $reqManip
+     * @param Symfony\Component\HttpFoundation\Request                               $request
+     * @param Symfony\Component\HttpFoundation\Response                              $response
+     * @param Symfony\Bundle\FrameworkBundle\Templating\EngineInterface              $engine
+     * @param Twig_Environment                                                       $twig
+     * @param Symfony\Bundle\FrameworkBundle\Controller\ControllerNameParser         $cnp
+     * @param Knp\RadBundle\HttpFoundation\RequestManipulator                        $reqManip
      * @param Symfony\Component\HttpKernel\Event\GetResponseForControllerResultEvent $event
-     * @param Knp\RadBundle\EventListener\MissingViewHandler $mvh
+     * @param Knp\RadBundle\EventListener\MissingViewHandler                         $mvh
+     * @param Twig_ExistsLoaderInterface                                             $teli
      */
-    function let($request, $twig, $response, $engine, $cnp, $reqManip, $event, $mvh)
+    function let($request, $twig, $response, $engine, $cnp, $reqManip, $event, $mvh, $teli)
     {
         $this->beConstructedWith($engine, $twig, $cnp, 'twig', 'App', $mvh, $reqManip);
 
         $event->getRequest()->willReturn($request);
     }
 
-    function it_should_create_a_view_response_when_controller_did_not_return_any($request, $response, $reqManip, $engine, $twig, $event, $mvh)
+    function it_should_create_a_view_response_when_controller_did_not_return_any($request, $response, $reqManip, $engine, $twig, $event, $mvh, $teli)
     {
         $reqManip->hasAttribute($request, '_controller')->willReturn(true);
         $reqManip->getAttribute($request, '_controller')->willReturn('App\Controller\CheeseController::eatAction');
 
         $request->getRequestFormat()->willReturn('html');
 
-        $twig->loadTemplate('App:Cheese:eat.html.twig')->willReturn();
+        $twig->getLoader()->willReturn($teli);
+        $teli->exists('App:Cheese:eat.html.twig')->willReturn(true);
         $engine->renderResponse('App:Cheese:eat.html.twig', array('foo' => 'bar'))->willReturn($response);
 
         $event->setResponse($response)->shouldBeCalled();
@@ -42,14 +44,15 @@ class ViewListenerSpec extends ObjectBehavior
         $this->onKernelView($event);
     }
 
-    function it_should_create_a_view_response_when_controller_return_null($request, $response, $reqManip, $engine, $twig, $event, $mvh)
+    function it_should_create_a_view_response_when_controller_return_null($request, $response, $reqManip, $engine, $twig, $event, $mvh, $teli)
     {
         $reqManip->hasAttribute($request, '_controller')->willReturn(true);
         $reqManip->getAttribute($request, '_controller')->willReturn('App\Controller\CheeseController::eatAction');
 
         $request->getRequestFormat()->willReturn('html');
 
-        $twig->loadTemplate('App:Cheese:eat.html.twig')->willReturn();
+        $twig->getLoader()->willReturn($teli);
+        $teli->exists('App:Cheese:eat.html.twig')->willReturn(true);
         $engine->renderResponse('App:Cheese:eat.html.twig', array())->willReturn($response);
 
         $event->setResponse($response)->shouldBeCalled();
@@ -61,7 +64,7 @@ class ViewListenerSpec extends ObjectBehavior
         $this->onKernelView($event);
     }
 
-    function it_should_resolve_controller_when_not_yet_resolved($request, $response, $reqManip, $engine, $twig, $event, $cnp, $mvh)
+    function it_should_resolve_controller_when_not_yet_resolved($request, $response, $reqManip, $engine, $twig, $event, $cnp, $mvh, $teli)
     {
         $reqManip->hasAttribute($request, '_controller')->willReturn(true);
         $reqManip->getAttribute($request, '_controller')->willReturn('App\Controller\CheeseController::eatAction');
@@ -70,7 +73,8 @@ class ViewListenerSpec extends ObjectBehavior
 
         $cnp->parse('App:Cheese:eat')->willReturn('App\Controller\CheeseController::eatAction');
 
-        $twig->loadTemplate('App:Cheese:eat.html.twig')->willReturn();
+        $twig->getLoader()->willReturn($teli);
+        $teli->exists('App:Cheese:eat.html.twig')->willReturn(true);
         $engine->renderResponse('App:Cheese:eat.html.twig', array('foo' => 'bar'))->willReturn($response);
 
         $event->setResponse($response)->shouldBeCalled();
@@ -82,14 +86,15 @@ class ViewListenerSpec extends ObjectBehavior
         $this->onKernelView($event);
     }
 
-    function it_should_use_the_right_template_depending_on_request_format($request, $response, $reqManip, $engine, $twig, $event, $cnp, $mvh)
+    function it_should_use_the_right_template_depending_on_request_format($request, $response, $reqManip, $engine, $twig, $event, $cnp, $mvh, $teli)
     {
         $reqManip->hasAttribute($request, '_controller')->willReturn(true);
         $reqManip->getAttribute($request, '_controller')->willReturn('App\Controller\CheeseController::eatAction');
 
         $request->getRequestFormat()->willReturn('xml');
 
-        $twig->loadTemplate('App:Cheese:eat.xml.twig')->willReturn();
+        $twig->getLoader()->willReturn($teli);
+        $teli->exists('App:Cheese:eat.xml.twig')->willReturn(true);
         $engine->renderResponse('App:Cheese:eat.xml.twig', array('foo' => 'bar'))->willReturn($response);
 
         $event->setResponse($response)->shouldBeCalled();
@@ -111,7 +116,7 @@ class ViewListenerSpec extends ObjectBehavior
         $this->onKernelView($event);
     }
 
-    function it_should_forward_event_to_missing_view_handler_when_view_does_not_exist($request, $response, $reqManip, $engine, $twig, $event, $cnp, $mvh)
+    function it_should_forward_event_to_missing_view_handler_when_view_does_not_exist($request, $response, $reqManip, $engine, $twig, $event, $cnp, $mvh, $teli)
     {
         $reqManip->hasAttribute($request, '_controller')->willReturn(true);
         $reqManip->getAttribute($request, '_controller')->willReturn('App\Controller\CheeseController::eatAction');
@@ -120,14 +125,15 @@ class ViewListenerSpec extends ObjectBehavior
 
         $event->getControllerResult()->willReturn(array('foo' => 'bar'));
 
-        $twig->loadTemplate('App:Cheese:eat.html.twig')->willThrow(new \Twig_Error_Loader('Unable to find template "App:Cheese:eat.html.twig".'));
+        $twig->getLoader()->willReturn($teli);
+        $teli->exists('App:Cheese:eat.html.twig')->willReturn(false);
 
         $mvh->handleMissingView($event, 'App:Cheese:eat.html.twig', array('foo' => 'bar'))->shouldBeCalled();
 
         $this->onKernelView($event);
     }
 
-    function it_should_deduce_view_with_correct_bundle_name($request, $response, $reqManip, $engine, $twig, $event, $cnp, $mvh)
+    function it_should_deduce_view_with_correct_bundle_name($request, $response, $reqManip, $engine, $twig, $event, $cnp, $mvh, $teli)
     {
         $this->beConstructedWith($engine, $twig, $cnp, 'twig', 'TestBundle', $mvh, $reqManip);
 
@@ -138,7 +144,8 @@ class ViewListenerSpec extends ObjectBehavior
 
         $event->getControllerResult()->willReturn(array('foo' => 'bar'));
 
-        $twig->loadTemplate('TestBundle:Cheese:eat.html.twig')->willThrow(new \Twig_Error_Loader('Unable to find template "TestBundle:Cheese:eat.html.twig".'));
+        $twig->getLoader()->willReturn($teli);
+        $teli->exists('TestBundle:Cheese:eat.html.twig')->willReturn(false);
         $mvh->handleMissingView($event, 'TestBundle:Cheese:eat.html.twig', array('foo' => 'bar'))->shouldBeCalled();
 
         $this->onKernelView($event);
@@ -155,7 +162,10 @@ class ViewListenerSpec extends ObjectBehavior
         $this->onKernelView($event);
     }
 
-    function it_should_not_handle_missing_view_if_template_exists_but_fails_to_load($request, $response, $reqManip, $engine, $twig, $event, $cnp, $mvh)
+    /**
+     * @param Twig_LoaderInterface $tli
+     */
+    function it_should_not_handle_missing_view_if_template_exists_but_fails_to_load($request, $response, $reqManip, $engine, $twig, $event, $cnp, $mvh, $tli)
     {
         $reqManip->hasAttribute($request, '_controller')->willReturn(true);
         $reqManip->getAttribute($request, '_controller')->willReturn('App\Controller\CheeseController::eatAction');
@@ -164,11 +174,10 @@ class ViewListenerSpec extends ObjectBehavior
 
         $event->getControllerResult()->willReturn(array('foo' => 'bar'));
 
-        $twig->loadTemplate('App:Cheese:eat.html.twig')->willThrow(new \Twig_Error_Loader('another unrelated error'));
+        $twig->getLoader()->willReturn($tli);
+        $tli->getSource('App:Cheese:eat.html.twig')->willThrow(new \Twig_Error_Loader('another unrelated error'));
         $mvh->handleMissingView(\Prophecy\Argument::cetera())->shouldNotBeCalled();
 
         $this->shouldThrow()->duringOnKernelView($event);
     }
-
-
 }


### PR DESCRIPTION
It now uses exists() method of the twig loader if it's an instance of
Twig_ExistsLoaderInterface.

Inspired by https://github.com/symfony/symfony/blob/master/src/Symfony/Bundle/WebProfilerBundle/Profiler/TemplateManager.php#L120-L136
