### PR TITLE
Revert "use AccessDeniedHttpException instead of AccessDeniedException"

### DIFF
--- a/Controller/Controller.php
+++ b/Controller/Controller.php
@@ -3,7 +3,7 @@
 namespace Knp\RadBundle\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Controller\Controller as BaseController;
-use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\HttpFoundation\Request;
 use Doctrine\ORM\EntityRepository;
 use Knp\RadBundle\Flash;
@@ -17,7 +17,7 @@ class Controller extends BaseController
 
     protected function createAccessDeniedException($message = 'Access Denied', \Exception $previous = null)
     {
-        return new AccessDeniedHttpException($message, $previous);
+        return new AccessDeniedException($message, $previous);
     }
 
     protected function getRepository($entity)


### PR DESCRIPTION
Turns out that I was wrong about this in the first place.

In short - `AccessDeniedException` is a lower level Exception, that is picked up by internal listeners, which in turn eventually throw a proper `AccessDeniedHttpException` in its place. Naming is really confusing and unintuitive, but it is what it is.

@weaverryan can probably give a better, more detailed explanation if needed
