### PR TITLE
[CSRF links] it should always check for csrf token, not just when _link_token is present in request.

### DIFF
--- a/EventListener/CsrfListener.php
+++ b/EventListener/CsrfListener.php
@@ -19,15 +19,20 @@ class CsrfListener
     public function onKernelRequest(GetResponseEvent $event)
     {
         $request = $event->getRequest();
-        if (!$request->request->has('_link_token')) {
+        if (false === $request->attributes->get('_check_csrf', false)) {
             return;
+        }
+        if (!$request->request->has('_link_token')) {
+            throw new \InvalidArgumentException(
+                'The CSRF token verification is activated but you did not send a token. Please submit a request with a valid csrf token.'
+            );
         }
 
         $token = $request->request->get('_link_token');
 
         if (!$this->csrfProvider->isCsrfTokenValid($this->intention, $token)) {
             throw new \InvalidArgumentException(
-                'The CSRF token is invalid. Please try to resubmit the form.'
+                'The CSRF token is invalid. Please submit a request with a valid csrf token.'
             );
         }
     }

--- a/spec/Knp/RadBundle/EventListener/CsrfListenerSpec.php
+++ b/spec/Knp/RadBundle/EventListener/CsrfListenerSpec.php
@@ -3,6 +3,7 @@
 namespace spec\Knp\RadBundle\EventListener;
 
 use PhpSpec\ObjectBehavior;
+use Prophecy\Argument as Arg;
 
 class CsrfListenerSpec extends ObjectBehavior
 {
@@ -11,17 +12,20 @@ class CsrfListenerSpec extends ObjectBehavior
      * @param Symfony\Component\HttpKernel\Event\GetResponseEvent                      $event
      * @param Symfony\Component\HttpFoundation\Request                                 $request
      * @param Symfony\Component\HttpFoundation\ParameterBag                            $requestBag
+     * @param Symfony\Component\HttpFoundation\ParameterBag                            $attributeBag
      */
-    function let($csrfProvider, $event, $request, $requestBag)
+    function let($csrfProvider, $event, $request, $requestBag, $attributeBag)
     {
         $event->getRequest()->willReturn($request);
         $request->request = $requestBag;
+        $request->attributes = $attributeBag;
 
         $this->beConstructedWith($csrfProvider);
     }
 
-    function its_onKernelRequest_should_continue_if_csrf_valid($event, $request, $requestBag, $csrfProvider)
+    function its_onKernelRequest_should_continue_if_csrf_valid($event, $request, $requestBag, $attributeBag, $csrfProvider)
     {
+        $attributeBag->get('_check_csrf', false)->shouldBeCalled()->willReturn(true);
         $requestBag->has('_link_token')->shouldBeCalled()->willReturn(true);
         $requestBag->get('_link_token')->shouldBeCalled()->willReturn('some token');
         $csrfProvider->isCsrfTokenValid('link', 'some token')->shouldBeCalled()->willReturn(true);
@@ -29,28 +33,42 @@ class CsrfListenerSpec extends ObjectBehavior
         $this->onKernelRequest($event);
     }
 
-    function its_onKernelRequest_should_continue_if_no_csrf_provided($event, $request, $requestBag, $csrfProvider)
+    function its_onKernelRequest_should_continue_if_no_csrf_provided_and_check_csrf_disabled($event, $request, $requestBag, $attributeBag, $csrfProvider)
     {
-        $requestBag->has('_link_token')->shouldBeCalled()->willReturn(false);
+        $attributeBag->get('_check_csrf', false)->shouldBeCalled()->willReturn(false);
         $requestBag->get('_link_token')->shouldNotBeCalled();
-        $csrfProvider->isCsrfTokenValid('link', 'some token')->shouldNotBeCalled();
+        $csrfProvider->isCsrfTokenValid('link', Arg::type('string'))->shouldNotBeCalled();
 
         $this->onKernelRequest($event);
     }
 
-    function its_onKernelRequest_should_throw_exception_if_csrf_invalid($event, $request, $requestBag, $csrfProvider)
+    function its_onKernelRequest_should_throw_exception_if_no_csrf_provided_and_check_csrf_enabled($event, $request, $requestBag, $attributeBag, $csrfProvider)
     {
+        $attributeBag->get('_check_csrf', false)->shouldBeCalled()->willReturn(true);
+        $requestBag->has('_link_token')->shouldBeCalled()->willReturn(false);
+        $requestBag->get('_link_token')->shouldNotBeCalled();
+        $csrfProvider->isCsrfTokenValid('link', Arg::type('string'))->shouldNotBeCalled();
+
+        $this->shouldThrow(new \InvalidArgumentException(
+            'The CSRF token verification is activated but you did not send a token. Please submit a request with a valid csrf token.'
+        ))->duringOnKernelRequest($event);
+    }
+
+    function its_onKernelRequest_should_throw_exception_if_csrf_invalid($event, $request, $requestBag, $attributeBag, $csrfProvider)
+    {
+        $attributeBag->get('_check_csrf', false)->shouldBeCalled()->willReturn(true);
         $requestBag->has('_link_token')->shouldBeCalled()->willReturn(true);
         $requestBag->get('_link_token')->shouldBeCalled()->willReturn('some token');
         $csrfProvider->isCsrfTokenValid('link', 'some token')->shouldBeCalled()->willReturn(false);
 
         $this->shouldThrow(new \InvalidArgumentException(
-            'The CSRF token is invalid. Please try to resubmit the form.'
+            'The CSRF token is invalid. Please submit a request with a valid csrf token.'
         ))->duringOnKernelRequest($event);
     }
 
-    function its_onKernelRequest_should_use_request_method_as_csrf_intention($event, $request, $requestBag, $csrfProvider)
+    function its_onKernelRequest_should_use_the_link_string_as_csrf_intention($event, $request, $requestBag, $attributeBag, $csrfProvider)
     {
+        $attributeBag->get('_check_csrf', false)->shouldBeCalled()->willReturn(true);
         $requestBag->has('_link_token')->shouldBeCalled()->willReturn(true);
         $requestBag->get('_link_token')->shouldBeCalled()->willReturn('some token');
         $csrfProvider->isCsrfTokenValid('link', 'some token')->shouldBeCalled()->willReturn(true);


### PR DESCRIPTION
Otherwise, it's too easy to generate CSRF attacks:

Just remove the `_link_token` parameter from the request and you're done!

We should find a way to verify routes that **need** to be checked. 

I see a possibility:
- mark the request to be **always** checked by adding request attribute `_check_csrf` (via routing for example)

fail here: https://github.com/KnpLabs/KnpRadBundle/blob/develop/EventListener/CsrfListener.php#L23
## Solution:

``` yaml
homepage:
    pattern: /
    defaults:
        _controller: FrameworkBundle:Template:template
        template: 'App::homepage.html.twig'
        _check_csrf: false

```
