### PR TITLE
[RFC] refactor resource resolver to resolve resource only if present as an action argument

### DIFF
--- a/EventListener/ResourceResolverListener.php
+++ b/EventListener/ResourceResolverListener.php
@@ -2,28 +2,47 @@
 
 namespace Knp\RadBundle\EventListener;
 
-use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
 use Knp\RadBundle\Resource\Resolver\RequestResolver;
 use Knp\RadBundle\Resource\Resolver\ResolutionFailureException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Knp\RadBundle\Reflection\ReflectionFactory;
 
 class ResourceResolverListener
 {
     private $requestResolver;
+    private $reflectionFactory;
 
-    public function __construct(RequestResolver $requestResolver)
+    public function __construct(RequestResolver $requestResolver, ReflectionFactory $reflectionFactory)
     {
         $this->requestResolver = $requestResolver;
+        $this->reflectionFactory = $reflectionFactory;
     }
 
-    public function onKernelRequest(GetResponseEvent $event)
+    public function onKernelController(FilterControllerEvent $event)
     {
         $request = $event->getRequest();
+        $controller = $event->getController();
 
-        try {
-            $this->requestResolver->resolveRequest($request);
-        } catch (ResolutionFailureException $e) {
-            throw new NotFoundHttpException('Unable to resolve resources.', $e);
+
+        foreach ($this->getParameters($controller) as $param) {
+            $name = $param->getName();
+            if (!$this->requestResolver->hasResourceOptions($request, $name)) {
+                continue;
+            }
+            try {
+                $this->requestResolver->resolveResource($request, $name);
+            } catch (ResolutionFailureException $e) {
+                if ($param->isOptional()) {
+                    continue;
+                }
+                throw new NotFoundHttpException('Unable to resolve resources.', $e);
+            }
         }
+    }
+
+    private function getParameters($controller)
+    {
+        return $this->reflectionFactory->getParameters($controller);
     }
 }

--- a/Reflection/ReflectionFactory.php
+++ b/Reflection/ReflectionFactory.php
@@ -8,4 +8,15 @@ class ReflectionFactory
     {
         return new \ReflectionClass($class);
     }
+
+    public function getParameters($controller)
+    {
+        if (is_array($controller)) {
+            $r = new \ReflectionMethod($controller[0], $controller[1]);
+        } else {
+            $r = new \ReflectionFunction($controller);
+        }
+
+        return $r->getParameters();
+    }
 }

--- a/Resource/Resolver/ArgumentResolver.php
+++ b/Resource/Resolver/ArgumentResolver.php
@@ -32,14 +32,18 @@ class ArgumentResolver
             throw new \InvalidArgumentException(
                 'You must pass either a `name` or a `value` option, but not both.'
             );
-        } elseif ($hasName) {
-            return $this->requestManipulator->getAttribute($request, $options['name']);
-        } elseif ($hasValue) {
-            return $options['value'];
-        } else {
-            throw new \InvalidArgumentException(
-                'You must path either a `name` or a `value` option.'
-            );
         }
+
+        if ($hasName) {
+            return $this->requestManipulator->getAttribute($request, $options['name']);
+        }
+
+        if ($hasValue) {
+            return $options['value'];
+        }
+
+        throw new \InvalidArgumentException(
+            'You must path either a `name` or a `value` option.'
+        );
     }
 }

--- a/Resource/Resolver/RequestResolver.php
+++ b/Resource/Resolver/RequestResolver.php
@@ -13,17 +13,35 @@ class RequestResolver
         $this->requestManipulator = $requestManipulator ?: new RequestManipulator();
     }
 
-    public function resolveRequest(Request $request)
+    public function resolveResource(Request $request, $name)
+    {
+        $options = $this->getResourceOptions($request, $name);
+        $resource = $this->resourceResolver->resolveResource($request, $options);
+        $this->setResource($request, $name, $resource);
+
+        return $resource;
+    }
+
+    public function hasResourceOptions(Request $request, $name)
     {
         if (false === $this->requestManipulator->hasAttribute($request, '_resources')) {
-            return;
+            return false;
         }
 
         $resources = $this->requestManipulator->getAttribute($request, '_resources');
 
-        foreach ($resources as $name => $options) {
-            $resource = $this->resourceResolver->resolveResource($request, $options);
-            $this->requestManipulator->setAttribute($request, $name, $resource);
-        }
+        return array_key_exists($name, $resources);
+    }
+
+    public function getResourceOptions(Request $request, $name)
+    {
+        $resources = $this->requestManipulator->getAttribute($request, '_resources');
+
+        return $resources[$name];
+    }
+
+    public function setResource(Request $request, $name, $resource)
+    {
+        $this->requestManipulator->setAttribute($request, $name, $resource);
     }
 }

--- a/Resources/config/resource_resolver_listener.xml
+++ b/Resources/config/resource_resolver_listener.xml
@@ -26,7 +26,7 @@
 
         <service id="knp_rad.event_listener.resource_resolver" class="%knp_rad.event_listener.resource_resolver.class%">
             <argument type="service" id="knp_rad.resource.resolver.request" />
-            <tag name="kernel.event_listener" event="kernel.request" />
+            <tag name="kernel.event_listener" event="kernel.controller" />
         </service>
     </services>
 

--- a/spec/Knp/RadBundle/EventListener/ResourceResolverListenerSpec.php
+++ b/spec/Knp/RadBundle/EventListener/ResourceResolverListenerSpec.php
@@ -7,31 +7,81 @@ use PhpSpec\ObjectBehavior;
 class ResourceResolverListenerSpec extends ObjectBehavior
 {
     /**
-     * @param Symfony\Component\HttpKernel\Event\GetResponseEvent $event
+     * @param Symfony\Component\HttpKernel\Event\FilterControllerEvent $event
      * @param Symfony\Component\HttpFoundation\Request $request
      * @param Knp\RadBundle\Resource\Resolver\RequestResolver $requestResolver
+     * @param Knp\RadBundle\Reflection\ReflectionFactory $reflectionFactory
      */
-    function let($event, $request, $requestResolver)
+    function let($requestResolver, $reflectionFactory)
     {
-        $this->beConstructedWith($requestResolver);
+        $this->beConstructedWith($requestResolver, $reflectionFactory);
     }
 
-
-    function it_should_resolve_resources_on_kernel_request($event, $request, $requestResolver)
+    /**
+     * @param \ReflectionParameter $param1
+     * @param \ReflectionParameter $param2
+     **/
+    function it_should_resolve_resources_on_kernel_controller($event, $request, $requestResolver, $reflectionFactory, $param1, $param2)
     {
+        $param1->getName()->willReturn('session');
+        $param2->getName()->willReturn('blogPost');
+        $reflectionFactory->getParameters(array('Test', 'test'))->shouldBeCalled()->willReturn(array(
+            $param1, $param2
+        ));
         $event->getRequest()->shouldBeCalled()->willReturn($request);
+        $event->getController()->shouldBeCalled()->willReturn(array('Test', 'test'));
+        $requestResolver->hasResourceOptions($request, 'session')->shouldBeCalled()->willReturn(true);
+        $requestResolver->hasResourceOptions($request, 'blogPost')->shouldBeCalled()->willReturn(true);
+        $requestResolver->resolveResource($request, 'session')->shouldBeCalled();
+        $requestResolver->resolveResource($request, 'blogPost')->shouldBeCalled();
 
-        $requestResolver->resolveRequest($request)->shouldBeCalled();
-
-        $this->onKernelRequest($event);
+        $this->onKernelController($event);
     }
 
-    function it_should_transform_resource_resolution_failures_into_404_errors($event, $request, $requestResolver)
+    /**
+     * @param \ReflectionParameter $param1
+     * @param \ReflectionParameter $param2
+     **/
+    function it_should_transform_resource_resolution_failures_into_404_errors($event, $request, $requestResolver, $reflectionFactory, $param1, $param2)
     {
+        $reflectionFactory->getParameters(array('Test', 'test'))->shouldBeCalled()->willReturn(array(
+            $param1, $param2
+        ));
+        $param1->getName()->willReturn('session');
+        $param1->isOptional()->willReturn(false);
+        $param2->getName()->willReturn('blogPost');
         $event->getRequest()->shouldBeCalled()->willReturn($request);
+        $event->getController()->shouldBeCalled()->willReturn(array('Test', 'test'));
 
-        $requestResolver->resolveRequest($request)->willThrow('Knp\RadBundle\Resource\Resolver\ResolutionFailureException');
+        $requestResolver->hasResourceOptions($request, 'session')->shouldBeCalled()->willReturn(true);
 
-        $this->shouldThrow('Symfony\Component\HttpKernel\Exception\NotFoundHttpException')->duringOnKernelRequest($event);
+        $requestResolver->resolveResource($request, 'session')->willThrow('Knp\RadBundle\Resource\Resolver\ResolutionFailureException');
+
+        $this->shouldThrow('Symfony\Component\HttpKernel\Exception\NotFoundHttpException')->duringOnKernelController($event);
+    }
+
+    /**
+     * @param \ReflectionParameter $param1
+     * @param \ReflectionParameter $param2
+     **/
+    function it_should_continue_resolution_if_param_optional($event, $request, $requestResolver, $reflectionFactory, $param1, $param2)
+    {
+        $reflectionFactory->getParameters(array('Test', 'test'))->shouldBeCalled()->willReturn(array(
+            $param1, $param2
+        ));
+        $param1->getName()->willReturn('session');
+        $param1->isOptional()->willReturn(true);
+        $param2->getName()->willReturn('blogPost');
+        $param2->isOptional()->willReturn(false);
+        $event->getRequest()->shouldBeCalled()->willReturn($request);
+        $event->getController()->shouldBeCalled()->willReturn(array('Test', 'test'));
+
+        $requestResolver->hasResourceOptions($request, 'session')->shouldBeCalled()->willReturn(true);
+        $requestResolver->hasResourceOptions($request, 'blogPost')->shouldBeCalled()->willReturn(true);
+
+        $requestResolver->resolveResource($request, 'session')->shouldBeCalled();
+        $requestResolver->resolveResource($request, 'blogPost')->willThrow('Knp\RadBundle\Resource\Resolver\ResolutionFailureException');
+
+        $this->shouldThrow('Symfony\Component\HttpKernel\Exception\NotFoundHttpException')->duringOnKernelController($event);
     }
 }

--- a/spec/Knp/RadBundle/Resource/Resolver/RequestResolverSpec.php
+++ b/spec/Knp/RadBundle/Resource/Resolver/RequestResolverSpec.php
@@ -30,6 +30,6 @@ class RequestResolverSpec extends ObjectBehavior
 
         $requestManipulator->setAttribute($request, 'cheese', $cheese)->shouldBeCalled();
 
-        $this->resolveRequest($request);
+        $this->resolveResource($request, 'cheese');
     }
 }


### PR DESCRIPTION
https://github.com/KnpLabs/KnpRadBundle/wiki/Resource-Resolvers

This is something similar to ParamConverters.
It's however far more flexible, and accessible for any request that has a `_resources` attribute.

associated routing:

``` yaml

App:Test:
    defaults:
        _resources:
            blogPosts:  {service: app.entity.blog_post_repository, method: findAll}
            blogPost:  {service: app.entity.blog_post_repository, method: find, arguments: [name: id]}
            session:  {service: service_container, method: get, arguments: [value: session]}

```

and controller:

``` php

class TestController
{
    public function indexAction()
    {
        (var_dump(func_get_args()));
    }

    public function showAction(array $blogPosts, BlogPost $blogPost, Session $session = null)
    {
        (var_dump(func_get_args()));
    }
}

```
