### PR TITLE
Resource resolver factory parameter is now optional

### DIFF
--- a/EventListener/ResourceResolverListener.php
+++ b/EventListener/ResourceResolverListener.php
@@ -13,10 +13,10 @@ class ResourceResolverListener
     private $requestResolver;
     private $reflectionFactory;
 
-    public function __construct(RequestResolver $requestResolver, ReflectionFactory $reflectionFactory)
+    public function __construct(RequestResolver $requestResolver, ReflectionFactory $reflectionFactory = null)
     {
         $this->requestResolver = $requestResolver;
-        $this->reflectionFactory = $reflectionFactory;
+        $this->reflectionFactory = null !== $reflectionFactory ? $reflectionFactory : new ReflectionFactory;
     }
 
     public function onKernelController(FilterControllerEvent $event)


### PR DESCRIPTION
It's a little bug. But actually the `ResourceResolverListener` service definition does not handle the ReflectionFactory :(
