### PR TITLE
Improved XML support and enabling improves

### DIFF
--- a/DependencyInjection/KnpRadExtension.php
+++ b/DependencyInjection/KnpRadExtension.php
@@ -57,13 +57,18 @@ class KnpRadExtension extends Extension
             $loader->load('datatable.xml');
         }
         $container->setParameter('knp_rad.csrf_link.intention', $config['csrf_links']['intention']);
-        if ($config['csrf_links']['enabled']) {
+        if ($this->isConfigEnabled(config['csrf_links'])) {
             $loader->load('link_attributes.xml');
         }
         $container->setParameter('knp_rad.flashes.trans_catalog', $config['flashes']['trans_catalog']);
-        if ($config['flashes']['enabled']) {
+        if ($this->isConfigEnabled($config['flashes'])) {
             $loader->load('flashes.xml');
         }
         $container->setParameter('knp_rad.decision_manager.id', $config['security']['decision_manager']);
+    }
+    
+    public function getNamespace()
+    {
+        return 'http://knplabs.com/schema/dic/rad';
     }
 }


### PR DESCRIPTION
#### Improved XML support

Before this PR:

``` xml
<config xmlns="http://example.org/schema/dic/knp_rad">
    <!-- ... -->
</config>
```

After:

``` xml
<config xmlns="http://knplabs.com/schema/dic/rad">
    <!-- ... -->
</config>
```

I did this change a month ago for the KnpMenuBundle too.
#### Enabling improves

Using [`Extension::isConfigEnabled`](https://github.com/symfony/DependencyInjection/blob/master/Extension/Extension.php#L118-125) allows configs using parameters, for instance:

``` yaml
knp_rad:
    flashes:
        enabled: "%kernel.debug%"
```
