### PR TITLE
[RFC] Introduce a new routing loader that permits extensibility.

### DIFF
--- a/Resources/config/routing_loader.xml
+++ b/Resources/config/routing_loader.xml
@@ -5,10 +5,15 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <parameters>
-        <parameter key="knp_rad.routing.loader.class">Knp\RadBundle\Routing\Loader\ConventionalLoader</parameter>
+        <parameter key="knp_rad.routing.old.loader.class">Knp\RadBundle\Routing\Loader\ConventionalLoader</parameter>
+        <parameter key="knp_rad.routing.conventional.loader.class">Knp\RadBundle\Routing\Conventional\Loader</parameter>
     </parameters>
     <services>
-        <service id="knp_rad.routing.loader" class="%knp_rad.routing.loader.class%" public="false">
+        <service id="knp_rad.routing.old.loader" class="%knp_rad.routing.old.loader.class%" public="false">
+            <argument type="service" id="file_locator" />
+            <tag name="routing.loader" />
+        </service>
+        <service id="knp_rad.routing.conventional.loader" class="%knp_rad.routing.conventional.loader.class%" public="false">
             <argument type="service" id="file_locator" />
             <tag name="routing.loader" />
         </service>

--- a/Routing/Conventional/Config.php
+++ b/Routing/Conventional/Config.php
@@ -1,0 +1,186 @@
+<?php
+
+namespace Knp\RadBundle\Routing\Conventional;
+
+class Config
+{
+    public $name;
+    public $parent;
+    private $config;
+
+    public function __construct($name, $config = null, Config $parent = null)
+    {
+        $this->name = $name;
+        if (!is_array($config)) {
+            $config = array('pattern' => $config);
+        }
+        $this->config = $config;
+        $this->parent = $parent;
+    }
+
+    public function getController()
+    {
+        if ($this->get('controller')) {
+            return $this->get('controller');
+        }
+        if ($this->parent) {
+            return $this->parent->getController();
+        }
+    }
+
+    public function getView()
+    {
+        if ($this->get('_view')) {
+            return $this->get('_view');
+        }
+        if ($this->parent) {
+            return $this->parent->getView();
+        }
+
+        return $this->name;
+    }
+
+    public function getPattern()
+    {
+        return $this->get('pattern');
+    }
+
+    public function getPrefix()
+    {
+        return $this->get('prefix');
+    }
+
+    public function getDefaults()
+    {
+        $defaults = $this->get('defaults', array());
+        if ($this->parent) {
+            $defaults = array_merge($this->parent->getDefaults(), $defaults);
+        }
+
+        return $defaults;
+    }
+
+    public function getRequirements()
+    {
+        $requirements = $this->get('requirements', array());
+        if ($this->parent) {
+            $requirements = array_merge($this->parent->getRequirements(), $requirements);
+        }
+
+        return $requirements;
+    }
+
+    public function getMethods()
+    {
+        $default = array();
+        if ($this->parent) {
+            $default = $this->parent->getMethods();
+        }
+
+        return $this->get('methods', $default);
+    }
+
+    public function getElements()
+    {
+        $elements = $this->getDefaultElements();
+
+        foreach ($elements as $key => $element) {
+            if (!in_array($key, $this->get('elements', array_keys($elements)))) {
+                unset($elements[$key]); // TODO improve this filter, couldn't get it work with array_intersect_*
+            }
+        }
+
+        $ignore = array_flip(array(
+            'parent',
+            'elements',
+            'pattern',
+            'prefix',
+            'controller',
+            'methods',
+            'defaults',
+            'requirements',
+        ));
+
+        $others = array_keys(array_diff_key($this->config, $ignore, $elements));
+        foreach ($others as $name) {
+            $config = $this->config[$name] ?: array();
+            if (!is_array($config)) {
+                $config = array('pattern' => $config);
+            }
+            $prefix = false === $this->getPrefix() ?: $this->name;
+            $elements[$name] = new static(
+                $name,
+                array_merge(array('pattern' => $name, 'prefix' => $prefix), $config),
+                $this
+            );
+        }
+
+        return $elements;
+    }
+
+    public function isRepresentant()
+    {
+        return $this->get('is_representant', false);
+    }
+
+    public function getRepresentant()
+    {
+        $elements = $this->getElements();
+        return current(array_filter($elements, function($element) {
+            return $element->isRepresentant();
+        }));
+    }
+
+    private function merge($path, array $config)
+    {
+        return array_merge($config, $this->get($path, array()));
+    }
+
+    private function get($path, $default = null)
+    {
+        if (isset($this->config[$path])) {
+            return $this->config[$path];
+        }
+
+        return $default;
+    }
+
+    private function getDefaultElements()
+    {
+        return array(
+            'index' => new static('index', $this->merge('index', array(
+                'methods'      => array('GET'),
+                'prefix'       => $this->name,
+            )), $this),
+            'new' => new static('new', $this->merge('new', array(
+                'methods'      => array('GET'),
+                'prefix'       => $this->name,
+            )), $this),
+            'create' => new static('create', $this->merge('create', array(
+                'methods'      => array('POST'),
+                'prefix'       => $this->name,
+            )), $this),
+            'edit' => new static('edit', $this->merge('edit', array(
+                'methods'      => array('GET'),
+                'requirements' => array('id' => '\d+'),
+                'prefix'       => $this->name,
+            )), $this),
+            'update' => new static('update', $this->merge('update', array(
+                'methods'      => array('PUT'),
+                'requirements' => array('id' => '\d+'),
+                'prefix'       => $this->name,
+            )), $this),
+            'show' => new static('show', $this->merge('show', array(
+                'methods'      => array('GET'),
+                'requirements' => array('id' => '\d+'),
+                'is_representant' => true,
+                'prefix'       => $this->name,
+            )), $this),
+            'delete' => new static('delete', $this->merge('delete', array(
+                'methods'      => array('DELETE'),
+                'requirements' => array('id' => '\d+'),
+                'prefix'       => $this->name,
+            )), $this),
+        );
+    }
+}

--- a/Routing/Conventional/Config/Factory.php
+++ b/Routing/Conventional/Config/Factory.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Knp\RadBundle\Routing\Conventional\Config;
+
+use Knp\RadBundle\Routing\Conventional\Config;
+
+class Factory
+{
+    private $parser;
+    private $index = array();
+
+    public function __construct(Parser $parser = null)
+    {
+        $this->parser = $parser ?: new Parser;
+    }
+
+    public function all($path)
+    {
+        $rawConfigs = $this->parser->parse($path);
+        if (empty($rawConfigs)) {
+            return array();
+        }
+
+        $all = array();
+        foreach ($rawConfigs as $name => $rawConfig) {
+            $all[] = $this->get($name, $rawConfigs);
+        }
+
+        return $all;
+    }
+
+    private function get($name, array $rawConfigs)
+    {
+        if (isset($this->index[$name])) {
+            return $this->index[$name];
+        }
+        if (!array_key_exists($name, $rawConfigs)) {
+            throw new \InvalidArgumentException(
+                sprintf('no "%s" in [%s]', $name, implode(', ', array_keys($rawConfigs)))
+            );
+        }
+        $rawConfig = $rawConfigs[$name];
+        $parent = null;
+        if (isset($rawConfig['parent'])) {
+            $parentCollection = $this->get($rawConfig['parent'], $rawConfigs);
+            $parent = $parentCollection->getRepresentant();
+        }
+
+        return $this->index[$name] = new Config($name, $rawConfig, $parent);
+    }
+}

--- a/Routing/Conventional/Config/Parser.php
+++ b/Routing/Conventional/Config/Parser.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Knp\RadBundle\Routing\Conventional\Config;
+
+use Symfony\Component\Yaml\Yaml;
+
+class Parser
+{
+    public function parse($path)
+    {
+        return Yaml::parse($path);
+    }
+}

--- a/Routing/Conventional/Factory.php
+++ b/Routing/Conventional/Factory.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Knp\RadBundle\Routing\Conventional;
+
+use Knp\RadBundle\Routing\Conventional\Generator;
+use Symfony\Component\Routing\Route;
+
+class Factory
+{
+    private $patterns;
+    private $controllerNames;
+    private $routes;
+    private $viewNames;
+
+    public function __construct(Generator\Pattern $patterns = null, Generator\ControllerName $controllerNames = null, Generator\RouteName $routes = null, Generator\ViewName $viewNames = null)
+    {
+        $this->patterns        = $patterns ?: new Generator\Pattern;
+        $this->controllerNames = $controllerNames ?: new Generator\ControllerName;
+        $this->routes          = $routes ?: new Generator\RouteName;
+        $this->viewNames       = $viewNames ?: new Generator\ViewName;
+    }
+
+    public function create(Config $config)
+    {
+        $name = $this->routes->generate($config);
+
+        return array($name, new Route(
+            $this->patterns->generate($config),
+            array_merge(array(
+                '_controller' => $this->controllerNames->generate($config),
+                '_view'       => $this->viewNames->generate($config),
+            ), $config->getDefaults()),
+            $config->getRequirements(),
+            array(), // options
+            null, // host
+            array(), // schemes
+            $config->getMethods()
+        ));
+    }
+}

--- a/Routing/Conventional/Generator.php
+++ b/Routing/Conventional/Generator.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Knp\RadBundle\Routing\Conventional;
+
+use Knp\RadBundle\Routing\Conventional\Config;
+
+interface Generator
+{
+    public function generate(Config $config);
+}

--- a/Routing/Conventional/Generator/ControllerName.php
+++ b/Routing/Conventional/Generator/ControllerName.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Knp\RadBundle\Routing\Conventional\Generator;
+
+use Knp\RadBundle\Routing\Conventional\Config;
+use Knp\RadBundle\Routing\Conventional\Generator;
+
+class ControllerName implements Generator
+{
+    private $map = array(
+        'create' => 'new',
+        'update' => 'edit',
+    );
+
+    public function __construct(array $map = null)
+    {
+        $this->map = $map ?: $this->map;
+    }
+
+    public function generate(Config $config)
+    {
+        $controller = $this->getControllerName($config);
+        $name = isset($this->map[$config->name]) ? $this->map[$config->name] : $config->name;
+
+        return sprintf('%s:%s%s', $controller, $name, $this->getActionSuffix($config));
+    }
+
+    private function getActionSuffix(Config $config)
+    {
+        if ($config->getController()) {
+            return 'Action';
+        }
+    }
+
+    private function getControllerName(Config $config)
+    {
+        if ($config->getController()) {
+            return $config->getController();
+        }
+
+        return $this->generateControllerHierarchy($config);
+    }
+
+    private function generateControllerHierarchy(Config $config)
+    {
+        $parts = array();
+        if ($config->parent) {
+            $parts[] = $this->generateControllerHierarchy($config->parent);
+        }
+        $parts[] = $this->getPrefix($config);
+
+        return implode('/', array_filter($parts));
+    }
+
+    /**
+     * prefix is the name (by default). This name can be of form: "App:Something"
+     *
+     * @return string
+     **/
+    private function getPrefix(Config $config)
+    {
+        $parts = explode(':', $config->name);
+
+        if (1 === count($parts)) {
+            return;
+        }
+
+        if ($config->parent && 2 === count($parts)) {
+            array_shift($parts);
+            return implode('/', $parts);
+        }
+
+        if (!$config->parent) {
+            return implode(':', $parts);
+        }
+    }
+}

--- a/Routing/Conventional/Generator/Pattern.php
+++ b/Routing/Conventional/Generator/Pattern.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Knp\RadBundle\Routing\Conventional\Generator;
+
+use Knp\RadBundle\Routing\Conventional\Generator;
+use Knp\RadBundle\Routing\Conventional\Config;
+
+class Pattern implements Generator
+{
+    private $map = array(
+        'index'  => '.{_format}',
+        'new'    => '/new.{_format}',
+        'create' => '/new.{_format}',
+        'edit'   => '/{id}/edit.{_format}',
+        'update' => '/{id}/edit.{_format}',
+        'show'   => '/{id}.{_format}',
+        'delete' => '/{id}.{_format}',
+    );
+
+    public function __construct(array $map = null)
+    {
+        $this->map = $map ?: $this->map;
+    }
+
+    /**
+     * recursively create a pattern, prepending parent "representant"(i.e: "show") pattern
+     * this parent pattern is modified to replace {id} with {<name>Id}, and remove {_format} if needed
+     *
+     * @return string
+     **/
+    public function generate(Config $config)
+    {
+        $parts = array();
+        if ($config->parent) {
+            $parts[] = str_replace(
+                array('{id}', '.{_format}'),
+                array(sprintf('{%sId}', $this->getPrefix($config->parent)), ''),
+                $this->generate($config->parent)
+            );
+        }
+        $parts[] = $this->getPrefix($config);
+
+        $prefix = implode('/', array_filter($parts));
+        $pattern = $this->getPattern($config);
+
+        if (isset($pattern[0]) && '/' !== $pattern[0] && '.' !== $pattern[0]) {
+            return rtrim($prefix, '/').'/'.$pattern;
+        }
+
+        return $prefix.$pattern;
+    }
+
+    /**
+     * prefix is the name (by default). This name can be of form: "App:Something"
+     *
+     * @return string
+     **/
+    private function getPrefix(Config $config)
+    {
+        $parts = explode(':', $config->getPrefix());
+        array_shift($parts);
+
+        return strtolower(str_replace(array('/', '\\'), '_', implode('_', $parts)));
+    }
+
+    private function getPattern(Config $config)
+    {
+        $pattern = $config->getPattern();
+        if (!empty($pattern)) {
+            return $pattern;
+        }
+
+        if (isset($this->map[$config->name])) {
+            return $this->map[$config->name];
+        }
+    }
+}

--- a/Routing/Conventional/Generator/RouteName.php
+++ b/Routing/Conventional/Generator/RouteName.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Knp\RadBundle\Routing\Conventional\Generator;
+
+use Knp\RadBundle\Routing\Conventional\Config;
+use Knp\RadBundle\Routing\Conventional\Generator;
+
+class RouteName implements Generator
+{
+    /**
+     * recursively build a route name
+     *
+     * @return string
+     **/
+    public function generate(Config $config)
+    {
+        $parts = array();
+        if ($config->parent) {
+            $parent = $config->parent->isRepresentant() ? $config->parent->parent : $config->parent;
+            $parts[] = $this->generate($parent);
+        }
+
+        $parts[] = $this->getPrefix($config);
+
+        return implode('_', array_filter($parts));
+    }
+
+    /**
+     * normalize name, removing root prefix (i.e: App) for nested routes
+     *
+     * @return string
+     **/
+    private function getPrefix(Config $config)
+    {
+        $parts = explode(':', $config->name);
+        if ($config->parent && 2 === count($parts)) {
+            // nested route that contains 'App:*
+            array_shift($parts);
+        }
+
+        return strtolower(str_replace(array('/', '\\', ':'), '_', implode('_', $parts)));
+    }
+}

--- a/Routing/Conventional/Generator/ViewName.php
+++ b/Routing/Conventional/Generator/ViewName.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Knp\RadBundle\Routing\Conventional\Generator;
+
+use Knp\RadBundle\Routing\Conventional\Config;
+use Knp\RadBundle\Routing\Conventional\Generator;
+
+class ViewName implements Generator
+{
+    public function generate(Config $config)
+    {
+        return sprintf('%s:%s', $config->getView(), $config->name);
+    }
+}

--- a/Routing/Conventional/Loader.php
+++ b/Routing/Conventional/Loader.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Knp\RadBundle\Routing\Conventional;
+
+use Symfony\Component\Config\Loader\FileLoader;
+use Symfony\Component\Config\FileLocatorInterface;
+use Symfony\Component\Config\Resource\FileResource;
+use Symfony\Component\Routing\RouteCollection;
+use Knp\RadBundle\Routing\Conventional\Factory;
+use Knp\RadBundle\Routing\Conventional\Config\Factory as Configs;
+
+class Loader extends FileLoader
+{
+    private $configs;
+    private $factory;
+
+    public function __construct(FileLocatorInterface $locator, Configs $configs = null, Factory $factory = null)
+    {
+        parent::__construct($locator);
+        $this->configs = $configs ?: new Configs;
+        $this->factory = $factory ?: new Factory;
+    }
+
+    public function supports($resource, $type = null)
+    {
+        return 'rad' === $type;
+    }
+
+    public function load($file, $type = null)
+    {
+        $path   = $this->locator->locate($file);
+        $collection = new RouteCollection;
+        $collection->addResource(new FileResource($file));
+
+        foreach ($this->configs->all($path) as $config) {
+            foreach ($config->getElements() as $element) {
+                list ($name, $route) = $this->factory->create($element);
+                $collection->add($name, $route);
+            }
+        }
+
+        return $collection;
+    }
+}

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -15,5 +15,3 @@ default:
             selenium2:   ~
             default_session: selenium2
             javascript_session: selenium2
-            show_auto: true
-            show_cmd: chrome %s

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     },
     "require-dev": {
         "behat/behat":                        "~3@dev",
-        "behat/mink-extension":               "*@dev",
+        "behat/mink-extension":               "~2@dev",
         "behat/mink-selenium2-driver":        "*@dev",
         "phpspec/phpspec":                    "~2@dev",
         "symfony/swiftmailer-bundle":         "~2.3",

--- a/features/Context/FeatureContext.php
+++ b/features/Context/FeatureContext.php
@@ -3,11 +3,10 @@
 use Behat\Behat\Context\ContextInterface;
 use Behat\Behat\Exception\PendingException;
 use Behat\Gherkin\Node\PyStringNode;
-use Behat\Gherkin\Node\TableNode;
-use Behat\Behat\Exception\BehaviorException;
 use Symfony\Component\Filesystem\Filesystem;
 use Behat\MinkExtension\Context\RawMinkContext;
 use Behat\Behat\Context\SnippetAcceptingContext;
+use Behat\Gherkin\Node\TableNode;
 
 class FeatureContext extends RawMinkContext implements SnippetAcceptingContext
 {
@@ -25,7 +24,8 @@ class FeatureContext extends RawMinkContext implements SnippetAcceptingContext
         $this->fs = new Filesystem;
         $this->tmpDir = __DIR__.'/fixtures/tmp';
         $this->fs->remove($this->tmpDir);
-        $this->writeContent($this->tmpDir.'/App/Resources/config/routing.yml');
+        $this->writeContent($this->tmpDir.'/App/Resources/config/rad.yml');
+        $this->writeContent($this->tmpDir.'/App/Resources/config/rad_convention.yml');
         $this->fs->mkdir($this->tmpDir.'/App/Entity');
         $this->app = new \fixtures\AppKernel;
     }
@@ -123,8 +123,9 @@ class FeatureContext extends RawMinkContext implements SnippetAcceptingContext
 
     /**
      * @When I visit :route page
+     * @When I visit :route page:
      */
-    public function visitRoute($route)
+    public function visitRoute($route, TableNode $params = null)
     {
         $this->createSchema();
         $this->app->boot();
@@ -132,7 +133,7 @@ class FeatureContext extends RawMinkContext implements SnippetAcceptingContext
             ->app
             ->getContainer()
             ->get('router')
-            ->generate($route)
+            ->generate($route, $params ? $params->getRowsHash() : array())
         ;
 
         $this->getMink()->getSession()->visit($this->locatePath($url));
@@ -151,6 +152,8 @@ class FeatureContext extends RawMinkContext implements SnippetAcceptingContext
     private function writeContent($path, $content = '')
     {
         $this->fs->mkdir(dirname($path));
-        file_put_contents($path, $content);
+        $fd = fopen($path, 'w');
+        fwrite($fd, $content);
+        fclose($fd);
     }
 }

--- a/features/Context/fixtures/routing.yml
+++ b/features/Context/fixtures/routing.yml
@@ -2,6 +2,10 @@ _knp_rad_assistant:
     resource: "@KnpRadBundle/Resources/config/routing/assistant.xml"
     prefix:   /_assistant
 
-_rad:
-    resource: "@App/Resources/config/routing.yml"
+_rad_convention:
+    resource: "@App/Resources/config/rad_convention.yml"
     type: rad_convention
+
+_rad:
+    resource: "@App/Resources/config/rad.yml"
+    type: rad

--- a/features/csrf_protection.feature
+++ b/features/csrf_protection.feature
@@ -18,7 +18,7 @@ Feature: CSRF protection for unsafe requests
             }
         }
         """
-        And I write in "App/Resources/config/routing.yml":
+        And I write in "App/Resources/config/rad_convention.yml":
         """
         App:Foo:show: ~
         App:Foo:delete:

--- a/features/domain_events.feature
+++ b/features/domain_events.feature
@@ -67,7 +67,7 @@ Feature: Domain events
                 tags:
                     - { name: doctrine.event_listener, event: onUserActivated }
         """
-        And I write in "App/Resources/config/routing.yml":
+        And I write in "App/Resources/config/rad.yml":
         """
         App:User: ~
         """

--- a/features/resource-resolver.feature
+++ b/features/resource-resolver.feature
@@ -23,7 +23,7 @@ Feature: Resolve request parameters to their corresponding resources
         """
 
     Scenario: static service resolution
-        Given I write in "App/Resources/config/routing.yml":
+        Given I write in "App/Resources/config/rad_convention.yml":
         """
         App:Foo:
             defaults:
@@ -33,7 +33,7 @@ Feature: Resolve request parameters to their corresponding resources
         Then I should see "Symfony\Bundle\FrameworkBundle\Routing\Router"
 
     Scenario: dynamic resolution
-        Given I write in "App/Resources/config/routing.yml":
+        Given I write in "App/Resources/config/rad_convention.yml":
         """
         App:Foo:
             defaults:
@@ -43,7 +43,7 @@ Feature: Resolve request parameters to their corresponding resources
         Then I should see "true"
 
     Scenario: expression language resolution
-        Given I write in "App/Resources/config/routing.yml":
+        Given I write in "App/Resources/config/rad_convention.yml":
         """
         App:Foo:
             defaults:

--- a/features/routing.feature
+++ b/features/routing.feature
@@ -1,0 +1,43 @@
+Feature: Configure routes using conventions
+    In order to normalize the way routes are created
+    As a RAD developer
+    I need rad bundle to provide a routing loader
+
+    Background:
+        Given I write in "App/Controller/RoutingController.php":
+        """
+        <?php namespace App\Controller {
+            class RoutingController {
+                public function indexAction() {}
+            }
+        }
+        """
+
+    Scenario: generate common routes
+        Given I write in "App/Resources/config/rad.yml":
+        """
+        App:Routing:
+            defaults: { _format: html }
+        """
+        When I visit "app_routing_index" page
+        Then I should see "App:Routing:index.html.twig"
+
+    Scenario: generate nested routes
+        Given I write in "App/Controller/Routing/SubController.php":
+        """
+        <?php namespace App\Controller\Routing {
+            class SubController {
+                public function indexAction() {}
+            }
+        }
+        """
+        And I write in "App/Resources/config/rad.yml":
+        """
+        App:Routing: ~
+        App:Sub:
+            defaults: { _format: html }
+            parent: 'App:Routing'
+        """
+        When I visit "app_routing_sub_index" page:
+            | routingId | 1 |
+        Then I should see "App:Routing/Sub:index.html.twig"

--- a/features/template_resolution.feature
+++ b/features/template_resolution.feature
@@ -14,7 +14,7 @@ Feature: Template resolution
             }
         }
         """
-        And I write in "App/Resources/config/routing.yml":
+        And I write in "App/Resources/config/rad_convention.yml":
         """
         App:Foo:bar: ~
         App:Foo:baz: ~

--- a/spec/Knp/RadBundle/Routing/Conventional/LoaderSpec.php
+++ b/spec/Knp/RadBundle/Routing/Conventional/LoaderSpec.php
@@ -1,0 +1,324 @@
+<?php
+
+namespace spec\Knp\RadBundle\Routing\Conventional;
+
+use PhpSpec\ObjectBehavior;
+use Symfony\Component\Config\FileLocatorInterface;
+use Knp\RadBundle\Routing\Conventional\Config\Factory as Configs;
+use Knp\RadBundle\Routing\Conventional\Config\Parser;
+
+class LoaderSpec extends ObjectBehavior
+{
+    function let(FileLocatorInterface $locator, Parser $yaml)
+    {
+        $locator->locate('routing.yml')->willReturn('yaml/file/path');
+    }
+
+    function it_supports_rad_resource_type($locator, $yaml)
+    {
+        $this->beConstructedWith($locator, new Configs($yaml->getWrappedObject()));
+        $this->supports('yaml/file/path', 'rad')->shouldReturn(true);
+    }
+
+    function it_generates_7_conventional_routes_by_default($locator, $yaml)
+    {
+        $yaml->parse('yaml/file/path')->willReturn(array(
+            'App:Cheese' => null
+        ));
+        $this->beConstructedWith($locator, new Configs($yaml->getWrappedObject()));
+        $collection = $this->load('routing.yml');
+
+        $collection->shouldHaveCount(7);
+    }
+
+    function it_generates_conventional_patterns($locator, $yaml)
+    {
+        $yaml->parse('yaml/file/path')->willReturn(array(
+            'App:Cheese' => null
+        ));
+        $this->beConstructedWith($locator, new Configs($yaml->getWrappedObject()));
+        $collection = $this->load('routing.yml');
+
+        $collection->get('app_cheese_index')->getPattern()->shouldReturn('/cheese.{_format}');
+        $collection->get('app_cheese_new')->getPattern()->shouldReturn('/cheese/new.{_format}');
+        $collection->get('app_cheese_create')->getPattern()->shouldReturn('/cheese/new.{_format}');
+        $collection->get('app_cheese_edit')->getPattern()->shouldReturn('/cheese/{id}/edit.{_format}');
+        $collection->get('app_cheese_update')->getPattern()->shouldReturn('/cheese/{id}/edit.{_format}');
+        $collection->get('app_cheese_show')->getPattern()->shouldReturn('/cheese/{id}.{_format}');
+        $collection->get('app_cheese_delete')->getPattern()->shouldReturn('/cheese/{id}.{_format}');
+    }
+
+    function it_generates_conventional_controller_names($locator, $yaml)
+    {
+        $yaml->parse('yaml/file/path')->willReturn(array(
+            'App:Cheese' => null
+        ));
+        $this->beConstructedWith($locator, new Configs($yaml->getWrappedObject()));
+        $collection = $this->load('routing.yml');
+
+        $collection->get('app_cheese_index')->getDefaults()->shouldReturn(array(
+            '_controller' => 'App:Cheese:index',
+            '_view' => 'App:Cheese:index',
+        ));
+        $collection->get('app_cheese_new')->getDefaults()->shouldReturn(array(
+            '_controller' => 'App:Cheese:new',
+            '_view' => 'App:Cheese:new',
+        ));
+        $collection->get('app_cheese_create')->getDefaults()->shouldReturn(array(
+            '_controller' => 'App:Cheese:new',
+            '_view' => 'App:Cheese:create',
+        ));
+        $collection->get('app_cheese_edit')->getDefaults()->shouldReturn(array(
+            '_controller' => 'App:Cheese:edit',
+            '_view' => 'App:Cheese:edit',
+        ));
+        $collection->get('app_cheese_update')->getDefaults()->shouldReturn(array(
+            '_controller' => 'App:Cheese:edit',
+            '_view' => 'App:Cheese:update',
+        ));
+        $collection->get('app_cheese_show')->getDefaults()->shouldReturn(array(
+            '_controller' => 'App:Cheese:show',
+            '_view' => 'App:Cheese:show',
+        ));
+        $collection->get('app_cheese_delete')->getDefaults()->shouldReturn(array(
+            '_controller' => 'App:Cheese:delete',
+            '_view' => 'App:Cheese:delete',
+        ));
+    }
+
+    function it_cascades_default_config($locator, $yaml)
+    {
+        $yaml->parse('yaml/file/path')->willReturn(array(
+            'App:Cheese' => array(
+                'defaults' => array(
+                    '_resources' => array(
+                        'object' => array('expr' => "request.get('id')"),
+                    ),
+                ),
+                'requirements' => array('_format' => 'html'),
+            ),
+        ));
+        $this->beConstructedWith($locator, new Configs($yaml->getWrappedObject()));
+        $collection = $this->load('routing.yml');
+
+        $collection->get('app_cheese_index')->getDefaults()->shouldReturn(array(
+            '_controller' => 'App:Cheese:index',
+            '_view' => 'App:Cheese:index',
+            '_resources' => array(
+                'object' => array('expr' => "request.get('id')"),
+            ),
+        ));
+    }
+
+    function it_overrides_default_config_explicitly($locator, $yaml)
+    {
+        $yaml->parse('yaml/file/path')->willReturn(array(
+            'App:Cheese' => array(
+                'defaults' => array(
+                    '_resources' => array(
+                        'object' => array('expr' => "request.get('id')"),
+                    ),
+                ),
+                'index' => array(
+                    'defaults' => array('_resources' => array()),
+                ),
+                'requirements' => array('_format' => 'html'),
+            ),
+        ));
+        $this->beConstructedWith($locator, new Configs($yaml->getWrappedObject()));
+        $collection = $this->load('routing.yml');
+
+        $collection->get('app_cheese_index')->getDefaults()->shouldReturn(array(
+            '_controller' => 'App:Cheese:index',
+            '_view' => 'App:Cheese:index',
+            '_resources' => array(),
+        ));
+    }
+
+    function its_controller_can_be_a_service($locator, $yaml)
+    {
+        $yaml->parse('yaml/file/path')->willReturn(array(
+            'App:Cheese' => array(
+                'controller' => 'knp_rad.controller.crud_controller',
+            ),
+        ));
+        $this->beConstructedWith($locator, new Configs($yaml->getWrappedObject()));
+        $collection = $this->load('routing.yml');
+
+        $collection->get('app_cheese_index')->getDefaults()->shouldReturn(array(
+            '_controller' => 'knp_rad.controller.crud_controller:indexAction',
+            '_view' => 'App:Cheese:index',
+        ));
+    }
+
+    function it_allows_to_add_new_routes($locator, $yaml)
+    {
+        $yaml->parse('yaml/file/path')->willReturn(array(
+            'App:Cheese' => array(
+                'custom' => null,
+            ),
+        ));
+        $this->beConstructedWith($locator, new Configs($yaml->getWrappedObject()));
+        $collection = $this->load('routing.yml');
+
+        $collection->get('app_cheese_custom')->getDefaults()->shouldReturn(array(
+            '_controller' => 'App:Cheese:custom',
+            '_view' => 'App:Cheese:custom',
+        ));
+        $collection->get('app_cheese_custom')->getPattern()->shouldReturn('/cheese/custom');
+    }
+
+    function it_allows_to_limit_number_of_generated_routes($locator, $yaml)
+    {
+        $yaml->parse('yaml/file/path')->willReturn(array(
+            'App:Cheese' => array(
+                'custom' => null,
+                'elements' => array('index', 'show'),
+            ),
+        ));
+        $this->beConstructedWith($locator, new Configs($yaml->getWrappedObject()));
+        $collection = $this->load('routing.yml');
+
+        $collection->shouldHaveCount(3);
+    }
+
+    function it_allows_to_disable_all_routes($locator, $yaml)
+    {
+        $yaml->parse('yaml/file/path')->willReturn(array(
+            'App:Cheese' => array(
+                'elements' => array(),
+            ),
+        ));
+        $this->beConstructedWith($locator, new Configs($yaml->getWrappedObject()));
+        $collection = $this->load('routing.yml');
+
+        $collection->shouldHaveCount(0);
+    }
+
+    function it_allows_new_routes_to_be_configured($locator, $yaml)
+    {
+        $yaml->parse('yaml/file/path')->willReturn(array(
+            'App:Cheese' => array(
+                'custom' => array('controller' => 'a different one'),
+            ),
+        ));
+        $this->beConstructedWith($locator, new Configs($yaml->getWrappedObject()));
+        $collection = $this->load('routing.yml');
+
+        $collection->get('app_cheese_custom')->getDefaults()->shouldReturn(array(
+            '_controller' => 'a different one:customAction',
+            '_view' => 'App:Cheese:custom',
+        ));
+        $collection->get('app_cheese_custom')->getPattern()->shouldReturn('/cheese/custom');
+    }
+
+    function it_uses_pattern_as_default_string_value($locator, $yaml)
+    {
+        $yaml->parse('yaml/file/path')->willReturn(array(
+            'App:Cheese' => array(
+                'custom' => '/patt{ern}/de/ouf'
+            ),
+        ));
+        $this->beConstructedWith($locator, new Configs($yaml->getWrappedObject()));
+        $collection = $this->load('routing.yml');
+
+        $collection->get('app_cheese_custom')->getDefaults()->shouldReturn(array(
+            '_controller' => 'App:Cheese:custom',
+            '_view' => 'App:Cheese:custom',
+        ));
+        $collection->get('app_cheese_custom')->getPattern()->shouldReturn('/cheese/patt{ern}/de/ouf');
+    }
+
+    public function it_can_be_prefixed($locator, $yaml)
+    {
+        $yaml->parse('yaml/file/path')->willReturn(array(
+            'App:Cheese' => array(
+                'custom' => array(
+                    'pattern' => '/patt{ern}/de/ouf',
+                    'prefix' => 'test:sub',
+                ),
+            ),
+        ));
+        $this->beConstructedWith($locator, new Configs($yaml->getWrappedObject()));
+        $collection = $this->load('routing.yml');
+
+        $collection->get('app_cheese_custom')->getPattern()->shouldReturn('/sub/patt{ern}/de/ouf');
+        $collection->get('app_cheese_custom')->getDefaults()->shouldReturn(array(
+            '_controller' => 'App:Cheese:custom',
+            '_view' => 'App:Cheese:custom',
+        ));
+    }
+
+    public function it_can_be_nested($locator, $yaml)
+    {
+        $yaml->parse('yaml/file/path')->willReturn(array(
+            'App:Food' => array(
+                'elements' => array('show'),
+            ),
+            'App:Cheese' => array(
+                'parent' => 'App:Food',
+                'elements' => array('show', 'index'),
+            ),
+            'App:Cantal' => array(
+                'parent' => 'App:Cheese',
+                'elements' => array('show', 'index'),
+            ),
+        ));
+        $this->beConstructedWith($locator, new Configs($yaml->getWrappedObject()));
+        $collection = $this->load('routing.yml');
+
+        $collection->get('app_food_cheese_show')->getPattern()->shouldReturn('/food/{foodId}/cheese/{id}.{_format}');
+        $collection->get('app_food_cheese_index')->getPattern()->shouldReturn('/food/{foodId}/cheese.{_format}');
+
+        $collection->get('app_food_cheese_cantal_show')->getPattern()->shouldReturn('/food/{foodId}/cheese/{cheeseId}/cantal/{id}.{_format}');
+    }
+
+    public function its_controllers_can_be_nested($locator, $yaml)
+    {
+        $yaml->parse('yaml/file/path')->willReturn(array(
+            'App:Food' => array(
+                'elements' => array('show'),
+            ),
+            'App:Cheese' => array(
+                'parent' => 'App:Food',
+                'elements' => array('show', 'index'),
+            ),
+            'App:Cantal' => array(
+                'parent' => 'App:Cheese',
+                'elements' => array('show', 'index'),
+            ),
+        ));
+        $this->beConstructedWith($locator, new Configs($yaml->getWrappedObject()));
+        $collection = $this->load('routing.yml');
+
+        $collection->get('app_food_cheese_cantal_show')->getDefaults()
+            ->shouldContain('App:Food/Cheese/Cantal:show')
+        ;
+    }
+
+    public function its_custom_controllers_should_not_be_nested($locator, $yaml)
+    {
+        $yaml->parse('yaml/file/path')->willReturn(array(
+            'App:Food' => array(
+                'controller' => 'app.controller.food',
+                'elements' => array('show'),
+            ),
+            'App:Cheese' => array(
+                'controller' => 'app.controller.food.cheese',
+                'parent' => 'App:Food',
+                'elements' => array('show', 'index'),
+            ),
+            'App:Cantal' => array(
+                'controller' => 'app.controller.food.cheese.cantal',
+                'parent' => 'App:Cheese',
+                'elements' => array('show', 'index'),
+            ),
+        ));
+        $this->beConstructedWith($locator, new Configs($yaml->getWrappedObject()));
+        $collection = $this->load('routing.yml');
+
+        $collection->get('app_food_cheese_cantal_show')->getDefaults()
+            ->shouldContain('app.controller.food.cheese.cantal:showAction')
+        ;
+    }
+}


### PR DESCRIPTION
Example:

``` yaml

App:Registration:
    elements: [index, new, create]
    controller: app.controller.registration
    calendar: ~
    defaults:
        _format: html
        _resources:
            form: { expr: service('app.form.registration') }

App:Contact:
    elements: [new, create]
    controller: app.controller.contact
    defaults:
        _format: html
        _resources:
            form: { expr: service('app.form.contact') }

App:StaticContent:
    elements: [index, edit]
    controller: app.controller.static_content
    prefix: false
    methods: [GET]
    defaults:
        _format: html
        _resources:
            form: { expr: service('app.form.staticcontent') }
    edit:
        requirements: { id: '\w+' }
    homepage:
        pattern: /
        defaults:
            _controller: FrameworkBundle:Template:template
            template: 'App:StaticContent:homepage.html.twig'

    locale_switch:
        methods: [GET|POST]
        pattern: /switch-locale

    about:
        pattern: /about
        defaults:
            _controller: FrameworkBundle:Template:template
            template: 'App:StaticContent:about.html.twig'

    portfolio:
        pattern: /portfolio
        defaults:
            _controller: FrameworkBundle:Template:template
            template: 'App:StaticContent:portfolio.html.twig'

```
