### PR TITLE
Allow custom alice providers

### DIFF
--- a/Alice/ProviderCollection.php
+++ b/Alice/ProviderCollection.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Knp\RadBundle\Alice;
+
+class ProviderCollection
+{
+    protected $providers;
+
+    public function __construct()
+    {
+        $this->providers = array();
+    }
+
+    public function addProvider($provider)
+    {
+        if (!in_array($provider, $this->providers)) {
+            $this->providers[] = $provider;
+        }
+
+        return $this;
+    }
+
+    public function getProviders()
+    {
+        return $this->providers;
+    }
+}

--- a/AppBundle/Bundle.php
+++ b/AppBundle/Bundle.php
@@ -13,6 +13,7 @@ class Bundle extends BaseBundle implements ConfigurableBundleInterface
     public function build(ContainerBuilder $container)
     {
         $container->addCompilerPass(new Compiler\RemoveUnavailableServicesPass);
+        $container->addCompilerPass(new Compiler\RegisterAliceProvidersPass($this));
         $container->addCompilerPass(new Compiler\RegisterDoctrineRepositoriesPass($this));
         $container->addCompilerPass(new Compiler\RegisterFormCreatorsPass);
         $container->addCompilerPass(new Compiler\RegisterTwigExtensionsPass($this));

--- a/DataFixtures/ORM/LoadAliceFixtures.php
+++ b/DataFixtures/ORM/LoadAliceFixtures.php
@@ -59,6 +59,11 @@ class LoadAliceFixtures extends AbstractFixture
 
     protected function getAliceOptions()
     {
-        return array('providers' => array($this));
+        return array('providers' => $this->getAliceProviders());
+    }
+
+    protected function getAliceProviders()
+    {
+        return $this->container->get('knp_rad.alice.provider_collection')->getProviders();
     }
 }

--- a/DependencyInjection/Compiler/RegisterAliceProvidersPass.php
+++ b/DependencyInjection/Compiler/RegisterAliceProvidersPass.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Knp\RadBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+class RegisterAliceProvidersPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        $collectionDefinition = $container->getDefinition('knp_rad.alice.provider_collection');
+        foreach (array_keys($container->findTaggedServiceIds('alice.provider')) as $id) {
+            $collectionDefinition->addMethodCall('addProvider', [ new Reference($id) ]);
+        }
+    }
+}

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -55,6 +55,7 @@ class Configuration implements ConfigurationInterface
                 ->booleanNode('form_manager')->defaultTrue()->end()
                 ->booleanNode('security_voter')->defaultTrue()->end()
                 ->booleanNode('datatable')->defaultTrue()->end()
+                ->booleanNode('alice')->defaultTrue()->end()
                 ->arrayNode('flashes')
                     ->addDefaultsIfNotSet()
                     ->canBeDisabled()

--- a/DependencyInjection/KnpRadExtension.php
+++ b/DependencyInjection/KnpRadExtension.php
@@ -65,6 +65,9 @@ class KnpRadExtension extends Extension
         if ($config['datatable']) {
             $loader->load('datatable.xml');
         }
+        if ($config['alice']) {
+            $loader->load('alice.xml');
+        }
         $container->setParameter('knp_rad.csrf_link.intention', $config['csrf_links']['intention']);
         if ($this->isConfigEnabled($container, $config['csrf_links'])) {
             $loader->load('link_attributes.xml');

--- a/Resources/config/alice.xml
+++ b/Resources/config/alice.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="knp_rad.alice.provider_collection.class">Knp\RadBundle\Alice\ProviderCollection</parameter>
+    </parameters>
+
+    <services>
+        <service id="knp_rad.alice.provider_collection" class="%knp_rad.alice.provider_collection.class%">
+        </service>
+    </services>
+</container>

--- a/Resources/doc/Doctrine_Fixtures_Alice.md
+++ b/Resources/doc/Doctrine_Fixtures_Alice.md
@@ -1,0 +1,25 @@
+Using Doctrine Fixtures with Alice
+==================================
+
+##Load Alice fixtures
+
+```bash
+php app/console doctrine:fixtures:load
+```
+
+##Add your own Alice fixtures
+
+You just have to add your *.yml* files in *src/YourBundle/Resources/doctrine/orm/*.
+
+##Register your own Alice providers
+
+You just have to tag your service with "*alice.provider*"
+
+```yml
+#Resources/config/services.yml
+services:
+    my.alice.provider:
+        class: MyBundle\Alice\MyProvider
+        tags:
+            - { name: alice.provider }
+```

--- a/spec/Knp/RadBundle/Alice/ProviderCollectionSpec.php
+++ b/spec/Knp/RadBundle/Alice/ProviderCollectionSpec.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace spec\Knp\RadBundle\Alice;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class ProviderCollectionSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Knp\RadBundle\Alice\ProviderCollection');
+    }
+
+    function it_returns_added_providers($provider1, $provider2)
+    {
+        $this->addProvider($provider1);
+        $this->getProviders()->shouldReturn(array($provider1));
+
+        $this->addProvider($provider2);
+        $this->getProviders()->shouldReturn(array($provider1, $provider2));
+    }
+}


### PR DESCRIPTION
Hello guys.

Just a little idea to allow custom alice providers.
# Using Doctrine Fixtures with Alice
## Load Alice fixtures

``` bash
php app/console doctrine:fixtures:load
```
## Add your own Alice fixtures

You just have to add your _.yml_ files in _src/YourBundle/Resources/doctrine/orm/_.
## Register your own Alice providers

You just have to tag your service with "_alice.provider_"

``` yml
#Resources/config/services.yml
services:
    my.alice.provider:
        class: MyBundle\Alice\MyProvider
        tags:
            - { name: alice.provider }
```
