### PR TITLE
Fix form loading from Type subnamespace

### DIFF
--- a/Form/FormTypeCreator.php
+++ b/Form/FormTypeCreator.php
@@ -38,13 +38,27 @@ class FormTypeCreator implements FormCreatorInterface
 
         $id = sprintf('app.form.%s%s_type', $currentPurpose, strtolower($this->fetcher->getShortClassName($object)));
         $class = sprintf('%s\\Form\\%s%sType', $bundle->getNamespace(), ucfirst($purpose), $this->fetcher->getShortClassName($object));
+
+        if (null === $type = $this->loadFormType($id, $class)) {
+            $id = sprintf('app.form.type.%s%s_type', $currentPurpose, strtolower($this->fetcher->getShortClassName($object)));
+            $class = sprintf('%s\\Form\\Type\\%s%sType', $bundle->getNamespace(), ucfirst($purpose), $this->fetcher->getShortClassName($object));
+
+            $type = $this->loadFormType($id, $class);
+        }
+
+        if (null === $type && null !== $purpose) {
+            // Let's try without purpose
+            $type = $this->getFormType($object);
+        }
+
+        return $type;
+    }
+
+    private function loadFormType($id, $class)
+    {
         $type = $this->getAlias($class, $id);
 
         if (!$this->formRegistry->hasType($type)) {
-            if ($purpose) {
-                // let's try without the purpose
-                return $this->getFormType($object);
-            }
 
             return null;
         }

--- a/spec/Knp/RadBundle/Form/FormTypeCreatorSpec.php
+++ b/spec/Knp/RadBundle/Form/FormTypeCreatorSpec.php
@@ -33,6 +33,7 @@ class FormTypeCreatorSpec extends ObjectBehavior
     {
         $fetcher->getShortClassName($object)->willReturn('Potato');
         $formRegistry->hasType('app.form.potato_type')->willReturn(false);
+        $formRegistry->hasType('app.form.type.potato_type')->willReturn(false);
         $fetcher->getClass($object)->willReturn('App\Entity\Potato');
         $fetcher->getParentClass('App\Entity\Potato')->willReturn(null);
 
@@ -63,6 +64,7 @@ class FormTypeCreatorSpec extends ObjectBehavior
     {
         $fetcher->getShortClassName($object)->willReturn('Cheese');
         $formRegistry->hasType('app.form.edit_cheese_type')->willReturn(true);
+        $formRegistry->hasType('app.form.type.edit_cheese_type')->willReturn(false);
         $formRegistry->hasType('app.form.cheese_type')->shouldNotBeCalled();
         $fetcher->getClass($object)->willReturn('App\Entity\Cheese');
         $factory->create('app.form.edit_cheese_type', $object, array())->shouldBeCalled()->willReturn($form);
@@ -82,6 +84,7 @@ class FormTypeCreatorSpec extends ObjectBehavior
         $fetcher->getShortClassName($object)->willReturn('Cheese');
         $fetcher->getShortClassName('App\Entity\Cheese')->willReturn('Cheese');
         $formRegistry->hasType('app.form.edit_cheese_type')->willReturn(false);
+        $formRegistry->hasType('app.form.type.edit_cheese_type')->willReturn(false);
         $formRegistry->hasType('app.form.cheese_type')->willReturn(true);
         $factory->create('app.form.cheese_type', $object, array())->shouldBeCalled()->willReturn($form);
 
@@ -102,6 +105,8 @@ class FormTypeCreatorSpec extends ObjectBehavior
         $fetcher->getParentClass('App\Entity\Cheese')->willReturn(null);
         $formRegistry->hasType('app.form.cheese_type')->willReturn(false);
         $formRegistry->hasType('app.form.edit_cheese_type')->willReturn(false);
+        $formRegistry->hasType('app.form.type.cheese_type')->willReturn(false);
+        $formRegistry->hasType('app.form.type.edit_cheese_type')->willReturn(false);
 
         $this->create($object, 'edit')->shouldReturn(null);
     }
@@ -121,7 +126,25 @@ class FormTypeCreatorSpec extends ObjectBehavior
         $fetcher->getParentClass('TestBundle\Entity\Cheese')->willReturn(null);
         $formRegistry->hasType('app.form.cheese_type')->willReturn(false);
         $formRegistry->hasType('app.form.edit_cheese_type')->willReturn(false);
+        $formRegistry->hasType('app.form.type.cheese_type')->willReturn(false);
+        $formRegistry->hasType('app.form.type.edit_cheese_type')->willReturn(false);
 
         $this->create($object, 'edit')->shouldReturn(null);
+    }
+
+    /**
+     * @param stdClass $object
+     * @param stdClass $formType
+     * @param Symfony\Component\Form\Form $form
+     */
+    function it_should_return_form_type_from_subnamespace_if_there_is_one($object, $fetcher, $factory, $form, $formRegistry)
+    {
+        $fetcher->getShortClassName($object)->willReturn('Cheese');
+        $formRegistry->hasType('app.form.cheese_type')->willReturn(null);
+        $formRegistry->hasType('app.form.type.cheese_type')->willReturn(true);
+        $fetcher->getClass($object)->willReturn('App\Entity\Cheese');
+        $factory->create('app.form.type.cheese_type', $object, array())->shouldBeCalled()->willReturn($form);
+
+        $this->create($object)->shouldReturn($form);
     }
 }


### PR DESCRIPTION
Actually, from types are autoloaded from following namespaces:
- **App\Form**
- **App\Form\Type**

But the FormTypeCreator don't allow to use from types from **App\Form\Type**
