### PR TITLE
Fixed mail helper controller class

### DIFF
--- a/Controller/Controller.php
+++ b/Controller/Controller.php
@@ -31,7 +31,7 @@ class Controller extends BaseController
 
     protected function createMessage($name, array $parameters = array(), $from = null, $to = null)
     {
-        return $this->getHelper('mail')->createMessage($name, $parameters, $from, $to);
+        return $this->getHelper('mail')->createMessage(get_class($this), $name, $parameters, $from, $to);
     }
 
     protected function send(\Swift_Mime_Message $message)

--- a/Controller/Helper/Mail.php
+++ b/Controller/Helper/Mail.php
@@ -17,9 +17,9 @@ class Mail
         $this->mailer = $mailer;
     }
 
-    public function createMessage($name, array $parameters = array(), $from = null, $to = null)
+    public function createMessage($controllerClass, $name, array $parameters = array(), $from = null, $to = null)
     {
-        $message = $this->factory->createMessage(get_class($this), $name, $parameters);
+        $message = $this->factory->createMessage($controllerClass, $name, $parameters);
 
         if ($from) {
             $message->setFrom($from);

--- a/Mailer/MessageFactory.php
+++ b/Mailer/MessageFactory.php
@@ -14,8 +14,8 @@ class MessageFactory
 
     public function __construct(Swift_Mailer $mailer, Twig_Environment $twig, BundleGuesser $bundleGuesser)
     {
-        $this->mailer     = $mailer;
-        $this->twig       = $twig;
+        $this->mailer = $mailer;
+        $this->twig = $twig;
         $this->bundleGuesser = $bundleGuesser;
     }
 


### PR DESCRIPTION
Current implem is trying to guess bundle class from the `Knp\RadBundle\Controller\Helper\Mailer` class which is always failing.

This fix allows to perform the class guessing against the current controller namespace.
