### PR TITLE
Fixed the message recorder plugin DIC tag

### DIFF
--- a/Resources/config/mailer_logger.xml
+++ b/Resources/config/mailer_logger.xml
@@ -14,7 +14,7 @@
 
         <service id="knp_rad.mailer.recorder" class="%knp_rad.mailer.recorder.class%" public="false">
             <argument type="service" id="knp_rad.mailer.logger" />
-            <tag name="swiftmailer.plugin" />
+            <tag name="swiftmailer.default.plugin" />
             <tag name="remove-when-missing" service="mailer" />
         </service>
 


### PR DESCRIPTION
As of v2.2.5, SwiftmailerBundle plugins must be registered using the
swiftmailer.default.plugin tag and not just swiftmailer.plugin anymore.

See https://github.com/symfony/SwiftmailerBundle/blob/v2.2.5/DependencyInjection/Compiler/RegisterPluginsPass.php
