### PR TITLE
[Domain Event] Use symfony dispatcher instead of doctrine one

### DIFF
--- a/DomainEvent/Event.php
+++ b/DomainEvent/Event.php
@@ -2,9 +2,9 @@
 
 namespace Knp\RadBundle\DomainEvent;
 
-use Doctrine\Common\EventArgs;
+use Symfony\Component\EventDispatcher\Event as BaseEvent;
 
-class Event extends EventArgs
+class Event extends BaseEvent
 {
     private $eventName;
     private $properties;

--- a/DomainEvent/Provider.php
+++ b/DomainEvent/Provider.php
@@ -5,9 +5,17 @@ namespace Knp\RadBundle\DomainEvent;
 interface Provider
 {
     /**
-     * empties and returns the list of events raised internally
+     * Empties and returns the list of events raised internally
      *
      * @return array
      **/
     public function popEvents();
+
+    /**
+     * Raise a domain event
+     *
+     * @param string $eventName
+     * @param array  $properties
+     */
+    public function raise($eventName, array $properties = array());
 }

--- a/DomainEvent/ProviderTrait.php
+++ b/DomainEvent/ProviderTrait.php
@@ -13,4 +13,9 @@ trait ProviderTrait
 
         return $events;
     }
+
+    public function raise($eventName, array $properties = array())
+    {
+        $this->events[] = new Event($eventName, $properties);
+    }
 }

--- a/Resources/config/domain_event.xml
+++ b/Resources/config/domain_event.xml
@@ -16,6 +16,7 @@
     <services>
 
         <service id="knp_rad.domain_event.dispatcher.doctrine" class="%knp_rad.domain_event.dispatcher.doctrine.class%">
+            <argument type="service" id="event_dispatcher" />
             <tag name="doctrine.event_subscriber" />
             <tag name="remove-when-missing" service="doctrine" />
         </service>

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,56 @@
+Upgrade from 2.6 to 2.7
+=======================
+
+Domain Events
+-------------
+
+Doctrine listener does not dispatch domain events through doctrine event manager
+anymore.  It now does it through a Symfony event dispatcher.  The one configured
+by default is the `event_dispatcher` service (Yes, it means that you have access
+to the whole event dispatcher symfony integration, like the debug toolbar).
+
+You must change your domain event listeners DIC definition:
+
+Before:
+```yaml
+services:
+    app.sync_listener:
+        class: App\SyncListener
+        tags:
+            - { name: doctrine.event_listener, event: onUserActivated }
+```
+
+After:
+```yaml
+services:
+    app.sync_listener:
+        class: App\SyncListener
+        tags:
+            - { name: kernel.event_listener, event: UserActivated }
+```
+
+Delayed event listeners definition must also be updated:
+
+Before:
+```yaml
+parameters:
+    knp_rad.domain_event.delayed_event_names: [UserActivated]
+
+services:
+    app.async_listener:
+        class: App\AsyncListener
+        tags:
+            - { name: doctrine.event_listener, event: onDelayedUserActivated }
+```
+
+After:
+```yaml
+parameters:
+    knp_rad.domain_event.delayed_event_names: [UserActivated]
+
+services:
+    app.async_listener:
+        class: App\AsyncListener
+        tags:
+            - { name: kernel.event_listener, event: UserActivated, method: onDelayedUserActivated }
+```

--- a/features/domain_events.feature
+++ b/features/domain_events.feature
@@ -75,7 +75,7 @@ Feature: Domain events
             app.sync_listener:
                 class: App\SyncListener
                 tags:
-                    - { name: doctrine.event_listener, event: onUserActivated }
+                    - { name: kernel.event_listener, event: UserActivated }
         """
         And I write in "App/Resources/config/rad.yml":
         """
@@ -106,7 +106,7 @@ Feature: Domain events
             app.async_listener:
                 class: App\AsyncListener
                 tags:
-                    - { name: doctrine.event_listener, event: onDelayedUserActivated }
+                    - { name: kernel.event_listener, event: UserActivated, method: onDelayedUserActivated }
         """
         When I visit "app_user_new" page
         Then the file "App/UserActivated" should contain "1"

--- a/spec/Knp/RadBundle/DomainEvent/Dispatcher/DoctrineSpec.php
+++ b/spec/Knp/RadBundle/DomainEvent/Dispatcher/DoctrineSpec.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace spec\Knp\RadBundle\DomainEvent\Dispatcher;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Doctrine\ORM\Event\PostFlushEventArgs;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\UnitOfWork;
+use Knp\RadBundle\DomainEvent\Provider;
+use Knp\RadBundle\DomainEvent\Event;
+
+class DoctrineSpec extends ObjectBehavior
+{
+    function let(EventDispatcherInterface $dispatcher)
+    {
+        $this->beConstructedWith($dispatcher);
+    }
+
+    function it_is_a_doctrine_event_subscriber()
+    {
+        $this->shouldBeAnInstanceOf('Doctrine\Common\EventSubscriber');
+    }
+
+    function it_subscribes_to_the_postFlush_event()
+    {
+        $this->getSubscribedEvents()->shouldReturn(array('postFlush'));
+    }
+
+    function it_dispatches_domain_events_after_doctrine_unit_of_work_has_been_flushed(
+        PostFlushEventArgs $event,
+        EntityManager $em,
+        UnitOfWork $uow,
+        Provider $entity,
+        Event $event1,
+        Event $event2,
+        $dispatcher
+    ) {
+        $event->getEntityManager()->willReturn($em);
+        $em->getUnitOfWork()->willReturn($uow);
+        $uow->getIdentityMap()->willReturn([[
+            $entity
+        ]]);
+        $entity->popEvents()->willReturn([$event1, $event2]);
+        $event1->getName()->willReturn('EntityCreated');
+        $event2->getName()->willReturn('PropertyUpdated');
+
+        $event1->setSubject($entity)->shouldBeCalled();
+        $event2->setSubject($entity)->shouldBeCalled();
+        $dispatcher->dispatch('EntityCreated', $event1)->shouldBeCalled();
+        $dispatcher->dispatch('PropertyUpdated', $event2)->shouldBeCalled();
+
+        $this->postFlush($event);
+    }
+}


### PR DESCRIPTION
Using doctrine event manager to dispatch domain events prevents domain
event listeners to depend on doctrine (circular reference). Plus, it
doesn't make much more sense to dispatch domain events through a storage
layer dispatcher.

This commit allows to dispatch domain events through an
event dispatcher (it uses the symfony event dispatcher by default).
