### PR TITLE
Prevented removed provider events to be ignored

### DIFF
--- a/DomainEvent/Dispatcher/Doctrine.php
+++ b/DomainEvent/Dispatcher/Doctrine.php
@@ -3,8 +3,7 @@
 namespace Knp\RadBundle\DomainEvent\Dispatcher;
 
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Doctrine\ORM\EntityManager;
-use Doctrine\Common\EventSubscriber;
+use Doctrine\ORM\Event\LifecycleEventArgs;
 use Doctrine\ORM\Event\PostFlushEventArgs;
 use Knp\RadBundle\DomainEvent\Provider;
 
@@ -15,38 +14,49 @@ use Knp\RadBundle\DomainEvent\Provider;
  * It's important to use postFlush to ensure everything is saved correctly (transaction commited)
  * before doing extra stuff (like sending emails f.e).
  **/
-class Doctrine implements EventSubscriber
+class Doctrine
 {
     protected $dispatcher;
+    protected $entities = [];
 
     public function __construct(EventDispatcherInterface $dispatcher)
     {
         $this->dispatcher = $dispatcher;
     }
 
-    public function getSubscribedEvents()
+    public function postPersist(LifecycleEventArgs $event)
     {
-        return array(
-            'postFlush',
-        );
+        $this->keepProvider($event);
+    }
+
+    public function postUpdate(LifecycleEventArgs $event)
+    {
+        $this->keepProvider($event);
+    }
+
+    public function postRemove(LifecycleEventArgs $event)
+    {
+        $this->keepProvider($event);
     }
 
     public function postFlush(PostFlushEventArgs $event)
     {
-        $em = $event->getEntityManager();
-        $identityMap = $em->getUnitOfWork()->getIdentityMap();
-
-        foreach ($identityMap as $class => $entities) {
-            foreach ($entities as $entity) {
-                if (!$entity instanceof Provider) {
-                    continue;
-                }
-
-                foreach ($entity->popEvents() as $event) {
-                    $event->setSubject($entity);
-                    $this->dispatcher->dispatch($event->getName(), $event);
-                }
+        foreach ($this->entities as $entity) {
+            foreach ($entity->popEvents() as $event) {
+                $event->setSubject($entity);
+                $this->dispatcher->dispatch($event->getName(), $event);
             }
         }
+    }
+
+    private function keepProvider(LifecycleEventArgs $event)
+    {
+        $entity = $event->getEntity();
+
+        if (!$entity instanceof Provider) {
+            return;
+        }
+
+        $this->entities[] = $entity;
     }
 }

--- a/Resources/config/domain_event.xml
+++ b/Resources/config/domain_event.xml
@@ -17,7 +17,10 @@
 
         <service id="knp_rad.domain_event.dispatcher.doctrine" class="%knp_rad.domain_event.dispatcher.doctrine.class%">
             <argument type="service" id="event_dispatcher" />
-            <tag name="doctrine.event_subscriber" />
+            <tag name="doctrine.event_listener" event="postPersist" />
+            <tag name="doctrine.event_listener" event="postUpdate" />
+            <tag name="doctrine.event_listener" event="postRemove" />
+            <tag name="doctrine.event_listener" event="postFlush" />
             <tag name="remove-when-missing" service="doctrine" />
         </service>
 


### PR DESCRIPTION
I believe that current implementation prevents removed provider events to be dispatched because it relies on unit of work's identity map which is truncated when entity is removed (see https://github.com/doctrine/doctrine2/blob/master/lib/Doctrine/ORM/UnitOfWork.php#L1307).

This PR suggests, as beberlei does in gist.github.com/beberlei/53cd6580d87b1f5cd9ca, to store persist, updated and removed entities in the listener and to rely on that.
