### PR TITLE
fix form alias

### DIFF
--- a/DependencyInjection/Compiler/RegisterFormTypesPass.php
+++ b/DependencyInjection/Compiler/RegisterFormTypesPass.php
@@ -60,11 +60,12 @@ class RegisterFormTypesPass implements CompilerPassInterface
             }
 
             $id = $this->serviceIdGenerator->generateForBundleClass($this->bundle, $class);
-            $alias = $this->getAlias($class, $id);
-
             if ($container->hasDefinition($id)) {
                 continue;
             }
+
+            $defaultAlias = $this->getDefaultAlias($id);
+            $alias = $this->getAlias($class, $defaultAlias);
 
             $definition = $this->definitionFactory->createDefinition($class);
             $container->setDefinition($id, $definition);
@@ -73,6 +74,16 @@ class RegisterFormTypesPass implements CompilerPassInterface
         }
 
         $container->getDefinition('form.extension')->replaceArgument(1, $types);
+    }
+
+    private function getDefaultAlias($id)
+    {
+        $parts = explode('.', $id);
+
+        $bundleName = $parts[0];
+        $formName = preg_replace('/_type$/', '', end($parts));
+
+        return sprintf('%s_%s', $bundleName, $formName);
     }
 
     private function getAlias($class, $default)

--- a/DependencyInjection/Compiler/RegisterFormTypesPass.php
+++ b/DependencyInjection/Compiler/RegisterFormTypesPass.php
@@ -64,8 +64,7 @@ class RegisterFormTypesPass implements CompilerPassInterface
                 continue;
             }
 
-            $defaultAlias = $this->getDefaultAlias($id);
-            $alias = $this->getAlias($class, $defaultAlias);
+            $alias = $this->getAlias($class);
 
             $definition = $this->definitionFactory->createDefinition($class);
             $container->setDefinition($id, $definition);
@@ -76,27 +75,8 @@ class RegisterFormTypesPass implements CompilerPassInterface
         $container->getDefinition('form.extension')->replaceArgument(1, $types);
     }
 
-    private function getDefaultAlias($id)
+    private function getAlias($class)
     {
-        $parts = explode('.', $id);
-
-        $bundleName = $parts[0];
-        $formName = preg_replace('/_type$/', '', end($parts));
-
-        return sprintf('%s_%s', $bundleName, $formName);
-    }
-
-    private function getAlias($class, $default)
-    {
-        if (!class_exists($class)) {
-            return $default;
-        }
-
-        try {
-            return unserialize(sprintf('O:%d:"%s":0:{}', strlen($class), $class))->getName();
-        } catch (\Exception $e) {
-        }
-
-        return $default;
+        return unserialize(sprintf('O:%d:"%s":0:{}', strlen($class), $class))->getName();
     }
 }

--- a/Form/FormTypeCreator.php
+++ b/Form/FormTypeCreator.php
@@ -61,7 +61,6 @@ class FormTypeCreator implements FormCreatorInterface
         $type = $this->getAlias($class, $alias);
 
         if (!$this->formRegistry->hasType($type)) {
-
             return null;
         }
 

--- a/Form/FormTypeCreator.php
+++ b/Form/FormTypeCreator.php
@@ -36,15 +36,16 @@ class FormTypeCreator implements FormCreatorInterface
     {
         $currentPurpose = $purpose ? $purpose.'_' : '';
         $bundle = $this->bundleGuesser->getBundleForClass($object);
+        $bundleName = preg_replace('/Bundle$/', '', $bundle->getName());
+        $bundleNamespace = $bundle->getNamespace();
 
-        $id = sprintf('app.form.%s%s_type', $currentPurpose, strtolower($this->fetcher->getShortClassName($object)));
-        $class = sprintf('%s\\Form\\%s%sType', $bundle->getNamespace(), Inflector::classify($purpose), $this->fetcher->getShortClassName($object));
+        $alias = sprintf('%s_%s%s', strtolower($bundleName), $currentPurpose, strtolower($this->fetcher->getShortClassName($object)));
+        $class = sprintf('%s\\Form\\%s%sType', $bundleNamespace, Inflector::classify($purpose), $this->fetcher->getShortClassName($object));
 
-        if (null === $type = $this->loadFormType($id, $class)) {
-            $id = sprintf('app.form.type.%s%s_type', $currentPurpose, strtolower($this->fetcher->getShortClassName($object)));
-            $class = sprintf('%s\\Form\\Type\\%s%sType', $bundle->getNamespace(), Inflector::classify($purpose), $this->fetcher->getShortClassName($object));
+        if (null === $type = $this->loadFormType($alias, $class)) {
+            $class = sprintf('%s\\Form\\Type\\%s%sType', $bundleNamespace, Inflector::classify($purpose), $this->fetcher->getShortClassName($object));
 
-            $type = $this->loadFormType($id, $class);
+            $type = $this->loadFormType($alias, $class);
         }
 
         if (null === $type && null !== $purpose) {
@@ -55,9 +56,9 @@ class FormTypeCreator implements FormCreatorInterface
         return $type;
     }
 
-    private function loadFormType($id, $class)
+    private function loadFormType($alias, $class)
     {
-        $type = $this->getAlias($class, $id);
+        $type = $this->getAlias($class, $alias);
 
         if (!$this->formRegistry->hasType($type)) {
 

--- a/spec/Knp/RadBundle/Form/FormTypeCreatorSpec.php
+++ b/spec/Knp/RadBundle/Form/FormTypeCreatorSpec.php
@@ -17,7 +17,10 @@ class FormTypeCreatorSpec extends ObjectBehavior
     function let($fetcher, $factory, $formRegistry, $bundleGuesser, $bundle)
     {
         $bundleGuesser->getBundleForClass(Argument::any())->willReturn($bundle);
-        $bundle->getNamespace()->willReturn('App');
+
+        $bundle->getNamespace()->willReturn('Star\Bundle\CraftBundle');
+        $bundle->getName()->willReturn('StarCraftBundle');
+
         $this->beConstructedWith($fetcher, $factory, $formRegistry, $bundleGuesser);
     }
 
@@ -32,10 +35,9 @@ class FormTypeCreatorSpec extends ObjectBehavior
     function it_should_return_null_if_there_is_no_form_type($object, $fetcher, $formRegistry)
     {
         $fetcher->getShortClassName($object)->willReturn('Potato');
-        $formRegistry->hasType('app.form.potato_type')->willReturn(false);
-        $formRegistry->hasType('app.form.type.potato_type')->willReturn(false);
-        $fetcher->getClass($object)->willReturn('App\Entity\Potato');
-        $fetcher->getParentClass('App\Entity\Potato')->willReturn(null);
+        $formRegistry->hasType('starcraft_potato')->willReturn(false);
+        $fetcher->getClass($object)->willReturn('Star\Bundle\CraftBundle\Entity\Potato');
+        $fetcher->getParentClass('Star\Bundle\CraftBundle\Entity\Potato')->willReturn(null);
 
         $this->create($object)->shouldReturn(null);
     }
@@ -48,9 +50,9 @@ class FormTypeCreatorSpec extends ObjectBehavior
     function it_should_return_form_type_if_there_is_one($object, $fetcher, $factory, $form, $formRegistry)
     {
         $fetcher->getShortClassName($object)->willReturn('Cheese');
-        $formRegistry->hasType('app.form.cheese_type')->willReturn(true);
-        $fetcher->getClass($object)->willReturn('App\Entity\Cheese');
-        $factory->create('app.form.cheese_type', $object, array())->shouldBeCalled()->willReturn($form);
+        $formRegistry->hasType('starcraft_cheese')->willReturn(true);
+        $fetcher->getClass($object)->willReturn('Star\Bundle\CraftBundle\Entity\Cheese');
+        $factory->create('starcraft_cheese', $object, array())->shouldBeCalled()->willReturn($form);
 
         $this->create($object)->shouldReturn($form);
     }
@@ -63,11 +65,10 @@ class FormTypeCreatorSpec extends ObjectBehavior
     function it_should_return_form_type_with_purpose_if_there_is_one($object, $fetcher, $factory, $form, $formRegistry)
     {
         $fetcher->getShortClassName($object)->willReturn('Cheese');
-        $formRegistry->hasType('app.form.edit_cheese_type')->willReturn(true);
-        $formRegistry->hasType('app.form.type.edit_cheese_type')->willReturn(false);
-        $formRegistry->hasType('app.form.cheese_type')->shouldNotBeCalled();
-        $fetcher->getClass($object)->willReturn('App\Entity\Cheese');
-        $factory->create('app.form.edit_cheese_type', $object, array())->shouldBeCalled()->willReturn($form);
+        $formRegistry->hasType('starcraft_edit_cheese')->willReturn(true);
+        $formRegistry->hasType('starcraft_cheese')->shouldNotBeCalled();
+        $fetcher->getClass($object)->willReturn('Star\Bundle\CraftBundle\Entity\Cheese');
+        $factory->create('starcraft_edit_cheese', $object, array())->shouldBeCalled()->willReturn($form);
 
         $this->create($object, 'edit')->shouldReturn($form);
     }
@@ -79,14 +80,13 @@ class FormTypeCreatorSpec extends ObjectBehavior
      */
     function it_should_fallback_on_default_form_type_if_given_purpose_has_no_associated_form_type($object, $fetcher, $factory, $form, $formRegistry)
     {
-        $fetcher->getClass($object)->willReturn('App\Entity\Cheese');
-        $fetcher->getParentClass('App\\Entity\\Cheese')->willReturn(null);
+        $fetcher->getClass($object)->willReturn('Star\Bundle\CraftBundle\Entity\Cheese');
+        $fetcher->getParentClass('Star\Bundle\CraftBundle\Entity\Cheese')->willReturn(null);
         $fetcher->getShortClassName($object)->willReturn('Cheese');
-        $fetcher->getShortClassName('App\Entity\Cheese')->willReturn('Cheese');
-        $formRegistry->hasType('app.form.edit_cheese_type')->willReturn(false);
-        $formRegistry->hasType('app.form.type.edit_cheese_type')->willReturn(false);
-        $formRegistry->hasType('app.form.cheese_type')->willReturn(true);
-        $factory->create('app.form.cheese_type', $object, array())->shouldBeCalled()->willReturn($form);
+        $fetcher->getShortClassName('Star\Bundle\CraftBundle\Entity\Cheese')->willReturn('Cheese');
+        $formRegistry->hasType('starcraft_edit_cheese')->willReturn(false);
+        $formRegistry->hasType('starcraft_cheese')->willReturn(true);
+        $factory->create('starcraft_cheese', $object, array())->shouldBeCalled()->willReturn($form);
 
         $this->create($object, 'edit')->shouldReturn($form);
     }
@@ -99,14 +99,12 @@ class FormTypeCreatorSpec extends ObjectBehavior
     function it_should_return_null_if_given_purpose_has_no_associated_form_type_and_no_default_form_type($object, $fetcher, $factory, $formType, $form, $formRegistry)
     {
         $fetcher->getShortClassName($object)->willReturn('Cheese');
-        $fetcher->getShortClassName('App\Entity\Cheese')->willReturn('Cheese');
-        $fetcher->getClass('App\Entity\Cheese')->willReturn('App\Entity\Cheese');
-        $fetcher->getClass($object)->willReturn('App\Entity\Cheese');
-        $fetcher->getParentClass('App\Entity\Cheese')->willReturn(null);
-        $formRegistry->hasType('app.form.cheese_type')->willReturn(false);
-        $formRegistry->hasType('app.form.edit_cheese_type')->willReturn(false);
-        $formRegistry->hasType('app.form.type.cheese_type')->willReturn(false);
-        $formRegistry->hasType('app.form.type.edit_cheese_type')->willReturn(false);
+        $fetcher->getShortClassName('Star\Bundle\CraftBundle\Entity\Cheese')->willReturn('Cheese');
+        $fetcher->getClass('Star\Bundle\CraftBundle\Entity\Cheese')->willReturn('Star\Bundle\Craft\Entity\Cheese');
+        $fetcher->getClass($object)->willReturn('Star\Bundle\CraftBundle\Entity\Cheese');
+        $fetcher->getParentClass('Star\Bundle\CraftBundle\Entity\Cheese')->willReturn(null);
+        $formRegistry->hasType('starcraft_cheese')->willReturn(false);
+        $formRegistry->hasType('starcraft_edit_cheese')->willReturn(false);
 
         $this->create($object, 'edit')->shouldReturn(null);
     }
@@ -118,33 +116,16 @@ class FormTypeCreatorSpec extends ObjectBehavior
      */
     function it_should_get_form_for_other_rad_bundle_name($object, $fetcher, $factory, $formType, $form, $formRegistry, $bundle)
     {
-        $bundle->getNamespace()->willReturn('TestBundle');
+        $bundle->getNamespace()->willReturn('App');
+        $bundle->getName()->willReturn('App');
         $fetcher->getShortClassName($object)->willReturn('Cheese');
-        $fetcher->getShortClassName('TestBundle\Entity\Cheese')->willReturn('Cheese');
-        $fetcher->getClass('TestBundle\Entity\Cheese')->willReturn('TestBundle\Entity\Cheese');
-        $fetcher->getClass($object)->willReturn('TestBundle\Entity\Cheese');
-        $fetcher->getParentClass('TestBundle\Entity\Cheese')->willReturn(null);
-        $formRegistry->hasType('app.form.cheese_type')->willReturn(false);
-        $formRegistry->hasType('app.form.edit_cheese_type')->willReturn(false);
-        $formRegistry->hasType('app.form.type.cheese_type')->willReturn(false);
-        $formRegistry->hasType('app.form.type.edit_cheese_type')->willReturn(false);
-
-        $this->create($object, 'edit')->shouldReturn(null);
-    }
-
-    /**
-     * @param stdClass $object
-     * @param stdClass $formType
-     * @param Symfony\Component\Form\Form $form
-     */
-    function it_should_return_form_type_from_subnamespace_if_there_is_one($object, $fetcher, $factory, $form, $formRegistry)
-    {
-        $fetcher->getShortClassName($object)->willReturn('Cheese');
-        $formRegistry->hasType('app.form.cheese_type')->willReturn(null);
-        $formRegistry->hasType('app.form.type.cheese_type')->willReturn(true);
+        $fetcher->getShortClassName('App\Entity\Cheese')->willReturn('Cheese');
+        $fetcher->getClass('App\Entity\Cheese')->willReturn('App\Entity\Cheese');
         $fetcher->getClass($object)->willReturn('App\Entity\Cheese');
-        $factory->create('app.form.type.cheese_type', $object, array())->shouldBeCalled()->willReturn($form);
+        $fetcher->getParentClass('App\Entity\Cheese')->willReturn(null);
+        $formRegistry->hasType('app_edit_cheese')->willReturn(true);
+        $factory->create('app_edit_cheese', $object, array())->shouldBeCalled()->willReturn($form);
 
-        $this->create($object)->shouldReturn($form);
+        $this->create($object, 'edit')->shouldReturn($form);
     }
 }

--- a/spec/Knp/RadBundle/Form/FormTypeCreatorSpec.php
+++ b/spec/Knp/RadBundle/Form/FormTypeCreatorSpec.php
@@ -18,7 +18,7 @@ class FormTypeCreatorSpec extends ObjectBehavior
     {
         $bundleGuesser->getBundleForClass(Argument::any())->willReturn($bundle);
 
-        $bundle->getNamespace()->willReturn('Star\Bundle\CraftBundle');
+        $bundle->getNamespace()->willReturn('Star\\Bundle\\CraftBundle');
         $bundle->getName()->willReturn('StarCraftBundle');
 
         $this->beConstructedWith($fetcher, $factory, $formRegistry, $bundleGuesser);
@@ -26,7 +26,7 @@ class FormTypeCreatorSpec extends ObjectBehavior
 
     function it_should_implement_form_creator_interface()
     {
-        $this->shouldBeAnInstanceOf('Knp\RadBundle\Form\FormCreatorInterface');
+        $this->shouldBeAnInstanceOf('Knp\\RadBundle\\Form\\FormCreatorInterface');
     }
 
     /**
@@ -34,10 +34,10 @@ class FormTypeCreatorSpec extends ObjectBehavior
      */
     function it_should_return_null_if_there_is_no_form_type($object, $fetcher, $formRegistry)
     {
-        $fetcher->getShortClassName($object)->willReturn('Potato');
-        $formRegistry->hasType('starcraft_potato')->willReturn(false);
-        $fetcher->getClass($object)->willReturn('Star\Bundle\CraftBundle\Entity\Potato');
-        $fetcher->getParentClass('Star\Bundle\CraftBundle\Entity\Potato')->willReturn(null);
+        $fetcher->getShortClassName($object)->willReturn('Orc');
+        $formRegistry->hasType('starcraft_orc')->willReturn(false);
+        $fetcher->getClass($object)->willReturn('Star\\Bundle\\CraftBundle\\Entity\\Orc');
+        $fetcher->getParentClass('Star\\Bundle\\CraftBundle\\Entity\\Orc')->willReturn(null);
 
         $this->create($object)->shouldReturn(null);
     }
@@ -49,10 +49,10 @@ class FormTypeCreatorSpec extends ObjectBehavior
      */
     function it_should_return_form_type_if_there_is_one($object, $fetcher, $factory, $form, $formRegistry)
     {
-        $fetcher->getShortClassName($object)->willReturn('Cheese');
-        $formRegistry->hasType('starcraft_cheese')->willReturn(true);
-        $fetcher->getClass($object)->willReturn('Star\Bundle\CraftBundle\Entity\Cheese');
-        $factory->create('starcraft_cheese', $object, array())->shouldBeCalled()->willReturn($form);
+        $fetcher->getShortClassName($object)->willReturn('Zerg');
+        $formRegistry->hasType('starcraft_zerg')->willReturn(true);
+        $fetcher->getClass($object)->willReturn('Star\\Bundle\\CraftBundle\\Entity\\Zerg');
+        $factory->create('starcraft_zerg', $object, array())->shouldBeCalled()->willReturn($form);
 
         $this->create($object)->shouldReturn($form);
     }
@@ -64,11 +64,11 @@ class FormTypeCreatorSpec extends ObjectBehavior
      */
     function it_should_return_form_type_with_purpose_if_there_is_one($object, $fetcher, $factory, $form, $formRegistry)
     {
-        $fetcher->getShortClassName($object)->willReturn('Cheese');
-        $formRegistry->hasType('starcraft_edit_cheese')->willReturn(true);
-        $formRegistry->hasType('starcraft_cheese')->shouldNotBeCalled();
-        $fetcher->getClass($object)->willReturn('Star\Bundle\CraftBundle\Entity\Cheese');
-        $factory->create('starcraft_edit_cheese', $object, array())->shouldBeCalled()->willReturn($form);
+        $fetcher->getShortClassName($object)->willReturn('Zerg');
+        $formRegistry->hasType('starcraft_edit_zerg')->willReturn(true);
+        $formRegistry->hasType('starcraft_zerg')->shouldNotBeCalled();
+        $fetcher->getClass($object)->willReturn('Star\\Bundle\\CraftBundle\\Entity\\Zerg');
+        $factory->create('starcraft_edit_zerg', $object, array())->shouldBeCalled()->willReturn($form);
 
         $this->create($object, 'edit')->shouldReturn($form);
     }
@@ -80,51 +80,13 @@ class FormTypeCreatorSpec extends ObjectBehavior
      */
     function it_should_fallback_on_default_form_type_if_given_purpose_has_no_associated_form_type($object, $fetcher, $factory, $form, $formRegistry)
     {
-        $fetcher->getClass($object)->willReturn('Star\Bundle\CraftBundle\Entity\Cheese');
-        $fetcher->getParentClass('Star\Bundle\CraftBundle\Entity\Cheese')->willReturn(null);
-        $fetcher->getShortClassName($object)->willReturn('Cheese');
-        $fetcher->getShortClassName('Star\Bundle\CraftBundle\Entity\Cheese')->willReturn('Cheese');
-        $formRegistry->hasType('starcraft_edit_cheese')->willReturn(false);
-        $formRegistry->hasType('starcraft_cheese')->willReturn(true);
-        $factory->create('starcraft_cheese', $object, array())->shouldBeCalled()->willReturn($form);
-
-        $this->create($object, 'edit')->shouldReturn($form);
-    }
-
-    /**
-     * @param stdClass $object
-     * @param stdClass $formType
-     * @param Symfony\Component\Form\Form $form
-     */
-    function it_should_return_null_if_given_purpose_has_no_associated_form_type_and_no_default_form_type($object, $fetcher, $factory, $formType, $form, $formRegistry)
-    {
-        $fetcher->getShortClassName($object)->willReturn('Cheese');
-        $fetcher->getShortClassName('Star\Bundle\CraftBundle\Entity\Cheese')->willReturn('Cheese');
-        $fetcher->getClass('Star\Bundle\CraftBundle\Entity\Cheese')->willReturn('Star\Bundle\Craft\Entity\Cheese');
-        $fetcher->getClass($object)->willReturn('Star\Bundle\CraftBundle\Entity\Cheese');
-        $fetcher->getParentClass('Star\Bundle\CraftBundle\Entity\Cheese')->willReturn(null);
-        $formRegistry->hasType('starcraft_cheese')->willReturn(false);
-        $formRegistry->hasType('starcraft_edit_cheese')->willReturn(false);
-
-        $this->create($object, 'edit')->shouldReturn(null);
-    }
-
-    /**
-     * @param stdClass $object
-     * @param stdClass $formType
-     * @param Symfony\Component\Form\Form $form
-     */
-    function it_should_get_form_for_other_rad_bundle_name($object, $fetcher, $factory, $formType, $form, $formRegistry, $bundle)
-    {
-        $bundle->getNamespace()->willReturn('App');
-        $bundle->getName()->willReturn('App');
-        $fetcher->getShortClassName($object)->willReturn('Cheese');
-        $fetcher->getShortClassName('App\Entity\Cheese')->willReturn('Cheese');
-        $fetcher->getClass('App\Entity\Cheese')->willReturn('App\Entity\Cheese');
-        $fetcher->getClass($object)->willReturn('App\Entity\Cheese');
-        $fetcher->getParentClass('App\Entity\Cheese')->willReturn(null);
-        $formRegistry->hasType('app_edit_cheese')->willReturn(true);
-        $factory->create('app_edit_cheese', $object, array())->shouldBeCalled()->willReturn($form);
+        $fetcher->getClass($object)->willReturn('Star\\Bundle\\CraftBundle\\Entity\\Zerg');
+        $fetcher->getParentClass('Star\\Bundle\\CraftBundle\\Entity\\Zerg')->willReturn(null);
+        $fetcher->getShortClassName($object)->willReturn('Zerg');
+        $fetcher->getShortClassName('Star\\Bundle\\CraftBundle\\Entity\\Zerg')->willReturn('Zerg');
+        $formRegistry->hasType('starcraft_edit_zerg')->willReturn(false);
+        $formRegistry->hasType('starcraft_zerg')->willReturn(true);
+        $factory->create('starcraft_zerg', $object, array())->shouldBeCalled()->willReturn($form);
 
         $this->create($object, 'edit')->shouldReturn($form);
     }


### PR DESCRIPTION
The dot `.` is not allowed in the form alias (or form type name), so the dot should be replaced by underscore in the compiler pass, otherwise the form type can't be found (in a situation that the form type is created manually and the entity is not in the same bundle as the form type). Of course, to make it work, the form type's `getName` method should return the proper alias name (eg. `app_form_new_task_type`)

I also suggest that the bundle name `app` should not hard coded in the form alias when `FormTypeCreator` try to find the proper form type with entity name, currently the form alias format is 

``` php
sprintf('app_form_%s%s_type', $purpose, $shortEntityClassName);
```

it could be better if change it to:

``` php
sprintf('%s_%s%s', $entityBundleName, $purpose, $shortEntityClassName);
```

The `form` and `type` are also be removed because they seem pointless and tedious(it must be a FORM TYPE's alias)

I'll update this PR if you agree with that. :)
