### PR TITLE
Add a short syntax to routing arguments

### DIFF
--- a/Resource/Resolver/OptionsBased.php
+++ b/Resource/Resolver/OptionsBased.php
@@ -34,14 +34,18 @@ class OptionsBased implements ResourceResolver
 
         $arguments = array();
         foreach ($options['arguments'] as $i => $argument) {
-            try {
-                $arguments[] = $this->argumentResolver->resolveArgument($request, $argument);
-            } catch (\Exception $e) {
-                throw new \RuntimeException(
-                    sprintf('Failed to resolve resource argument[%s].', $i),
-                    0,
-                    $e
-                );
+            if (is_string($argument)) {
+                $arguments[] = $this->argumentResolver->resolveName($request, $argument);
+            } else {
+                try {
+                    $arguments[] = $this->argumentResolver->resolveArgument($request, $argument);
+                } catch (\Exception $e) {
+                    throw new \RuntimeException(
+                        sprintf('Failed to resolve resource argument[%s].', $i),
+                        0,
+                        $e
+                    );
+                }
             }
         }
 

--- a/Resource/Resolver/OptionsBased/ArgumentResolver.php
+++ b/Resource/Resolver/OptionsBased/ArgumentResolver.php
@@ -34,7 +34,7 @@ class ArgumentResolver
         }
 
         if ($hasName) {
-            return $this->requestManipulator->getAttribute($request, $options['name']);
+            return $this->resolveName($request, $options['name']);
         }
 
         if ($hasValue) {
@@ -44,5 +44,10 @@ class ArgumentResolver
         throw new \InvalidArgumentException(
             'You must path either a `name` or a `value` option.'
         );
+    }
+
+    public function resolveName(Request $request, $name)
+    {
+        return $this->requestManipulator->getAttribute($request, $name);
     }
 }


### PR DESCRIPTION
A string argument is now a `name` argument by default.

Instead of using :

```
resources:
    edit:
        defaults:
            _resources:
                entity:
                    …
                    arguments: [{name: foo}, {value: 5}, {name: bar}, {value: norf}]
```

You can now use the short syntax :

```
arguments: [foo, {value: 5}, bar, {value: norf}]
```

`arguments: [id]` is now equivalent to `arguments: [{name: id}]`.

(Thanks to @PedroTroller )
