### PR TITLE
Stabilizing composer.json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php: [5.4, 5.5, 5.6, hhvm]
 matrix:
     allow_failures:
         - php: hhvm
+        - env: SYMFONY_VERSION='2.7.*@dev'
     include:
         - php: 5.4
           env: SYMFONY_VERSION='2.4.*'

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,19 +3,25 @@ language: php
 php: [5.4, 5.5, 5.6, hhvm]
 
 matrix:
-  allow_failures:
-    - php: hhvm
-
-cache:
-  directories:
-    - vendor
+    allow_failures:
+        - php: hhvm
+    include:
+        - php: 5.4
+          env: SYMFONY_VERSION='2.4.*'
+        - php: 5.4
+          env: SYMFONY_VERSION='2.5.*'
+        - php: 5.4
+          env: SYMFONY_VERSION='2.6.*'
+        - php: 5.4
+          env: SYMFONY_VERSION='2.7.*@dev'
 
 before_script:
-  - composer install --prefer-source --dev
-  - phantomjs --version
-  - phantomjs --webdriver=4444 &
-  - php -S localhost:8080 -t features/Context/fixtures &
-  - 'curl -H "Accept: text/plain" https://security.sensiolabs.org/check_lock -F lock=@composer.lock -s | grep "No known"'
+    - composer selfupdate
+    - if [ "$SYMFONY_VERSION" != "" ]; then composer require symfony/symfony=$SYMFONY_VERSION; else composer install; fi;
+    - phantomjs --version
+    - phantomjs --webdriver=4444 &
+    - php -S localhost:8080 -t features/Context/fixtures &
+    - 'curl -H "Accept: text/plain" https://security.sensiolabs.org/check_lock -F lock=@composer.lock -s | grep "No known"'
 
 script:
     - ./bin/phpspec run -fpretty

--- a/composer.json
+++ b/composer.json
@@ -16,11 +16,11 @@
         "fzaninotto/faker":         "~1.2"
     },
     "require-dev": {
-        "behat/behat":                        "~3@dev",
-        "behat/mink-extension":               "~2@dev",
-        "behat/mink-selenium2-driver":        "*@dev",
-        "behat/mink-goutte-driver":           "*@dev",
-        "phpspec/phpspec":                    "~2@dev",
+        "behat/behat":                        "~3.0",
+        "behat/mink-extension":               "~2.0",
+        "behat/mink-goutte-driver":           "~1.0",
+        "behat/mink-selenium2-driver":        "~1.1",
+        "phpspec/phpspec":                    "~2.0",
         "symfony/swiftmailer-bundle":         "~2.3",
         "doctrine/orm":                       "~2.4",
         "doctrine/doctrine-fixtures-bundle":  "*",
@@ -33,7 +33,6 @@
         "symfony/swiftmailer-bundle":        "To take advantage of the Rad mailer logger in your tests",
         "doctrine/orm":                      "To take advantage of the Rad password hash updater listener"
     },
-    "minimum-stability": "dev",
     "config": {
         "bin-dir": "bin"
     },

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php":                      ">=5.4",
-        "symfony/symfony":          "~2.4",
+        "symfony/symfony":          "~2.4,<2.7",
         "nelmio/alice":             "~1.5",
         "fzaninotto/faker":         "~1.2"
     },


### PR DESCRIPTION
This fix prevents to rely on symfony 2.7.\* (currently master of symfony/symfony) in travis builds.

It also adds a build matrix to make sure that the bundle is retro compatible with symfony 2.4 and 2.5, compatible with current stable (2.6).

Plus it adds a build to foresee what problems will bring next version of symfony (but this build should be allowed to fail). 
# TODO
- [x] Allow build symfony 2.7 to fail
- [x] Exclude symfony 2.7 to use the rad bundle (as it's not today compatible with it)
