### PR TITLE
Fix for deprecated Twig classes

### DIFF
--- a/Twig/DataTableTwigExtension.php
+++ b/Twig/DataTableTwigExtension.php
@@ -15,16 +15,16 @@ class DataTableTwigExtension extends \Twig_Extension
     public function getFunctions()
     {
         return array(
-            'bootstrap_datatable'       => new \Twig_Function_Method($this, 'getDataTableRender', array('is_safe' => array('html'))),
-            'bootstrap_datatable_row'   => new \Twig_Function_Method($this, 'getDataTableRowRender', array('is_safe' => array('html'))),
+            new \Twig_SimpleFunction('bootstrap_datatable', array($this, 'getDataTableRender'), array('is_safe' => array('html'))),
+            new \Twig_SimpleFunction('bootstrap_datatable_row', array($this, 'getDataTableRowRender'), array('is_safe' => array('html'))),
         );
     }
 
     public function getFilters()
     {
         return array(
-            'toArray'           => new \Twig_Filter_Method($this, 'toArrayFilter'),
-            'toHeadersArray'    => new \Twig_Filter_Method($this, 'toHeadersFilter'),
+            new \Twig_SimpleFilter('toArray', array($this, 'toArrayFilter')),
+            new \Twig_SimpleFilter('toHeadersArray', array($this, 'toHeadersFilter')),
         );
     }
 

--- a/Twig/LinkAttributesExtension.php
+++ b/Twig/LinkAttributesExtension.php
@@ -23,8 +23,8 @@ class LinkAttributesExtension extends \Twig_Extension
     public function getFunctions()
     {
         return array(
-            'link_attr' => new \Twig_Function_Method($this, 'getLinkAttributes', array('is_safe' => array('html'))),
-            'link_csrf' => new \Twig_Function_Method($this, 'getCsrf'),
+            new \Twig_SimpleFunction('link_attr', array($this, 'getLinkAttributes'), array('is_safe' => array('html'))),
+            new \Twig_SimpleFunction('link_csrf', array($this, 'getCsrf')),
         );
     }
 


### PR DESCRIPTION
- The Twig_Function_Method class is deprecated since version 1.12 and will be removed in 2.0. Use Twig_SimpleFunction instead.
- The Twig_Filter_Method class is deprecated since version 1.12 and will be removed in 2.0. Use Twig_SimpleFilter instead.
